### PR TITLE
add support for base fields

### DIFF
--- a/workbench
+++ b/workbench
@@ -535,7 +535,7 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s',
     datefmt='%d-%b-%y %H:%M:%S')
 
-if config['check']:
+if 'check' in config.keys():
     check_input(config, args)
 
 if config['task'] == 'create':

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -161,6 +161,18 @@ def get_field_definitions(config):
             entity_type = item['attributes']['entity_type']
             field_definitions[field_name]['entity_type'] = entity_type
 
+    base_field_override_url = config['host'] + '/jsonapi/base_field_override/base_field_override?filter[type][condition][path]=bundle&filter[type][condition][value]=' + config['content_type']
+    base_field_override_response = issue_request(config, 'GET', base_field_override_url, headers)
+    if base_field_override_response.status_code == 200:
+        field_config = json.loads(base_field_override_response.text)
+        for item in field_config['data']:
+            field_name = item['attributes']['field_name']
+            required = item['attributes']['required']
+            field_definitions[field_name]['required'] = required
+            # E.g., comment, media, node.
+            entity_type = item['attributes']['entity_type']
+            field_definitions[field_name]['entity_type'] = entity_type
+
     return field_definitions
 
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -168,10 +168,14 @@ def get_field_definitions(config):
         for item in field_config['data']:
             field_name = item['attributes']['field_name']
             required = item['attributes']['required']
-            field_definitions[field_name]['required'] = required
-            # E.g., comment, media, node.
+            field_type = item['attributes']['field_type']
             entity_type = item['attributes']['entity_type']
-            field_definitions[field_name]['entity_type'] = entity_type
+            field_definitions[field_name] = {
+                'cardinality': 1,
+                'field_type': field_type,
+                'required': required,
+                'entity_type': entity_type
+            }
 
     return field_definitions
 


### PR DESCRIPTION
Issue: #66

Oh, hey! I already did have a fork I can issue PRs from setup. Okay.

This PR includes the base fields for the configured content type to `get_field_definitions(config)` so that workbench can push up things like the node's 'Published' status.