### PR TITLE
updated validation

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -3432,7 +3432,8 @@ def get_extension_from_mimetype(mimetype):
     map = {'image/jpeg': '.jpg',
            'image/jp2': '.jp2',
            'image/png': '.png',
-           'application/octet-stream': '.bin'
+           'application/octet-stream': '.bin',
+           'audio/mpeg': '.mp3'
            }
     if mimetype in map:
         return map[mimetype]

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -2406,7 +2406,7 @@ def prepare_term_id(config, vocab_ids, term):
             # Split the namespace/vocab ID from the term name on ':'.
             namespaced = re.search(':', term)
             if namespaced:
-                [vocab_id, term_name] = term.split(':')
+                [vocab_id, term_name] = term.split(':', maxsplit=1)
                 tid = create_term(config, vocab_id.strip(), term_name.strip())
                 return tid
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -859,11 +859,14 @@ def check_input(config, args):
             validate_url_aliases_csv_data = get_csv_data(config)
             validate_url_aliases(config, validate_url_aliases_csv_data)
 
-        # Specific to creating paged content. Current, if 'parent_id' is present
-        # in the CSV file, so must 'field_weight' and 'field_member_of'.
+        # Specific to creating aggregated content such as collections, compound objects and paged content. Current, if 'parent_id' is present
+        # in the CSV file 'field_member_of' is mandatory.
         if 'parent_id' in csv_column_headers:
-            if ('field_weight' not in csv_column_headers or 'field_member_of' not in csv_column_headers):
-                message = 'If your CSV file contains a "parent_id" column, it must also contain "field_weight" and "field_member_of" columns.'
+            if ('field_weight' not in csv_column_headers):
+                message = 'If ingesting paged content, or compound objects where order is required a "field_weight" column is required.'
+                logging.info(message)
+            if ('field_member_of' not in csv_column_headers):
+                message = 'If your CSV file contains a "parent_id" column, it must also contain "field_member_of" column.'
                 logging.error(message)
                 sys.exit('Error: ' + message)
         drupal_fieldnames = []


### PR DESCRIPTION
[## Link to Github issue](https://github.com/mjordan/islandora_workbench/issues/279)

Allows unweighted compound ingests to pass validation

## What does thie PR do?

A CSV with parent_id doesn't need a field_weight to work.  This changes validation

## What changes were made?

Removed a single condition, updated inline comments, add a notice if field_weight was missing

## How to test / verify this PR?

Run a CSV with parent_id as a column header but now field_weight.  Test to see that ingest still works

## Interested Parties

@mjordan_

---

## Checklist

* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an addiional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
