### PR TITLE
Added content type check

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -621,6 +621,11 @@ def ping_islandora(config, print_message=True):
         print(message)
 
 
+def ping_content_type(config):
+    url = f"{config['host']}/admin/structure/types/manage/{config['content_type']}"
+    return issue_request(config, 'GET', url).status_code
+
+
 def ping_media_bundle(config, bundle_name):
     """Ping the Media bunlde/type to see if it exists. Return the status code,
        a 200 if it exists or a 404 if it doesn't exist or the Media Type REST resource
@@ -817,6 +822,10 @@ def get_field_definitions(config, entity_type, bundle_type=None):
 def get_entity_fields(config, entity_type, bundle_type):
     """Get all the fields configured on a bundle.
     """
+    if ping_content_type(config) == 404:
+        message = f"Content type '{config['content_type']}' not defined on {config['host']}."
+        logging.error(message)
+        sys.exit('Error: ' + message)
     fields_endpoint = config['host'] + '/entity/entity_form_display/' + \
         entity_type + '.' + bundle_type + '.default?_format=json'
     bundle_type_response = issue_request(config, 'GET', fields_endpoint)


### PR DESCRIPTION
## Link to Github issue or other discussion

> **[Issue 375 - adds content type check](https://github.com/mjordan/islandora_workbench/issues/375)** 

## What does this PR do?

> notifies user if the chosen content type does not exist on their Drupal installation

## What changes were made?

> Added a function to check for content type, and then runs that check before we attempt to grab fields

## How to test / veryify this PR?

> Create a config with a bogus content type and try to use it.  You should get an error
## Interested Parties

>  @mjordan

---

## Checklist

* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an addiional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
