### PR TITLE
Issue 374

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -121,7 +121,8 @@ class WorkbenchConfig:
             'excel_csv_filename': 'excel.csv',
             'ignore_csv_columns': list(),
             'use_node_title_for_media': False,
-            'use_node_title_for_media_title': True,
+            'use_nid_in_media_title': False,
+            'field_for_media_title': False,
             'delete_tmp_upload': False,
             'list_missing_drupal_fields': False,
             'secondary_tasks': None,
@@ -166,8 +167,17 @@ class WorkbenchConfig:
         if type_check.status_code == 404:
             message = f"Content type {self.config['content_type']} not defined on {self.config['host']}."
             error_messages.append(message)
+        mutators = ['use_node_title_for_media', 'use_nid_in_media_title', 'field_for_media_title']
+        selected = [mutator for mutator in mutators if self.config[mutator]]
+        if len(selected) > 1:
+            message = f"You may only select one of {mutators}.\n  - This config  has selected {selected}."
+            error_messages.append(message)
+
         if error_messages:
-            sys.exit('Error: ' + message)
+            output = ''
+            for error_message in error_messages:
+                output += f"{error_message}\n"
+            sys.exit('Error: ' + output)
 
     # Convenience function for debugging - Prints config to console screen.
     def print_config(self):

--- a/create.yml
+++ b/create.yml
@@ -1,4 +1,4 @@
 task: create
-host: "http://localhost:8000"
+host: "https://islandora.traefik.me"
 username: admin
-password: islandora
+password: elmwood

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -155,6 +155,8 @@ def set_config_defaults(args):
         config['use_node_title_for_media'] = False
     if 'use_nid_in_media_title' not in config:
         config['use_nid_in_media_title'] = False
+    if 'field_for_media_title' not in config:
+        config['field_for_media_title'] = False
     if 'delete_tmp_upload' not in config:
         config['delete_tmp_upload'] = False
     if 'list_missing_drupal_fields' not in config:
@@ -2231,6 +2233,8 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
                     media_name = os.path.basename(filename)
         if config['use_nid_in_media_title']:
             media_name = f"{node_id}-Original"
+        if config['field_for_media_title']:
+            media_name = node_csv_row[config['field_for_media_title']].replace(':', '_')
 
 
         media_json = {
@@ -4380,6 +4384,9 @@ def get_prepocessed_file_path(config, file_fieldname, node_csv_row):
         else:
             extension = os.path.splitext(sections.path)[1]
             filename = sections.path.split("/")[-1]
+            downloaded_file_path = os.path.join(subdir, filename)
+        if config['field_for_media_title']:
+            filename =node_csv_row[config['field_for_media_title']]
             downloaded_file_path = os.path.join(subdir, filename)
 
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -153,8 +153,8 @@ def set_config_defaults(args):
         config['ignore_csv_columns'] = list()
     if 'use_node_title_for_media' not in config:
         config['use_node_title_for_media'] = False
-    if 'use_node_title_for_media_title' not in config:
-        config['use_node_title_for_media_title'] = True
+    if 'use_nid_in_media_title' not in config:
+        config['use_nid_in_media_title'] = False
     if 'delete_tmp_upload' not in config:
         config['delete_tmp_upload'] = False
     if 'list_missing_drupal_fields' not in config:
@@ -2219,7 +2219,8 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
 
         media_field = config['media_bundle_file_fields'][media_type]
 
-        if config['use_node_title_for_media_title']:
+        media_name = os.path.basename(filename)
+        if config['use_node_title_for_media']:
             if 'title' in node_csv_row:
                 media_name = node_csv_row['title']
             else:
@@ -2228,8 +2229,9 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
                     message = 'Cannot access node " + node_id + ", so cannot get its title for use in media title. Using filename instead.'
                     logging.warning(message)
                     media_name = os.path.basename(filename)
-        else:
-            media_name = os.path.basename(filename)
+        if config['use_nid_in_media_title']:
+            media_name = f"{node_id}-Original"
+
 
         media_json = {
             "bundle": [{
@@ -4379,6 +4381,7 @@ def get_prepocessed_file_path(config, file_fieldname, node_csv_row):
             extension = os.path.splitext(sections.path)[1]
             filename = sections.path.split("/")[-1]
             downloaded_file_path = os.path.join(subdir, filename)
+
 
         if extension == '':
             try:

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -34,226 +34,6 @@ checked_terms = list()
 newly_created_terms = list()
 
 
-def set_config_defaults(args):
-    """Convert the YAML configuration data into an array for easy use.
-       Also set some sensible default config values.
-    """
-    # Check existence of configuration file.
-    if not os.path.exists(args.config):
-        # Since the main logger gets its log file location from this file, we
-        # need to define a local logger to write to the default log file location,
-        # 'workbench.log'.
-        logging.basicConfig(
-            filename='workbench.log',
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%d-%b-%y %H:%M:%S')
-        message = 'Error: Configuration file "' + args.config + '" not found.'
-        logging.error(message)
-        sys.exit(message)
-
-    try:
-        with open(args.config, 'r') as f:
-            config_file_contents = f.read()
-            original_config_data = yaml.load(config_file_contents)
-            # Convert all keys to lower case.
-            config_data = collections.OrderedDict()
-            for k, v in original_config_data.items():
-                if isinstance(k, str):
-                    k = k.lower()
-                    config_data[k] = v
-    except YAMLError as e:
-        # Since the main logger gets its log file location from this file, we
-        # need to define a local logger to write to the default log file location,
-        # 'workbench.log'.
-        logging.basicConfig(
-            filename='workbench.log',
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%d-%b-%y %H:%M:%S')
-
-        message = 'Error: There appears to be a YAML syntax error with the configuration file "' + args.config + '".' + \
-            ' More detail is available in the Workbench log. If you use an online YAML validator to find the error,' + \
-            ' BE SURE to remove your Drupal hostname and user credentials first.'
-        logging.exception(message)
-        sys.exit(message)
-
-    config = {}
-    for k, v in config_data.items():
-        config[k] = v
-
-    # Add the location of the config file. We do not
-    # check for this in the config file itself.
-    if os.path.isabs(args.config):
-        config['config_file_path'] = args.config
-    else:
-        config['config_file_path'] = os.path.join(os.getcwd(), args.config)
-    # Set up defaults for some settings.
-    if 'input_dir' not in config:
-        config['input_dir'] = 'input_data'
-    if 'input_csv' not in config:
-        config['input_csv'] = 'metadata.csv'
-    if 'media_use_tid' not in config:
-        config['media_use_tid'] = 'http://pcdm.org/use#OriginalFile'
-    # @todo: remove 'drupal_filesystem' when Workbench drops support
-    # for create_islandora_media().
-    if 'drupal_filesystem' not in config:
-        config['drupal_filesystem'] = 'fedora://'
-    if 'id_field' not in config:
-        config['id_field'] = 'id'
-    if 'content_type' not in config:
-        config['content_type'] = 'islandora_object'
-    if 'delimiter' not in config:
-        config['delimiter'] = ','
-    if 'subdelimiter' not in config:
-        config['subdelimiter'] = '|'
-    if 'log_file_path' not in config:
-        config['log_file_path'] = 'workbench.log'
-    if 'log_file_mode' not in config:
-        config['log_file_mode'] = 'a'
-    if 'allow_missing_files' not in config:
-        config['allow_missing_files'] = False
-    if 'update_mode' not in config:
-        config['update_mode'] = 'replace'
-    if 'validate_title_length' not in config:
-        config['validate_title_length'] = True
-    if 'paged_content_from_directories' not in config:
-        config['paged_content_from_directories'] = False
-    if 'delete_media_with_nodes' not in config:
-        config['delete_media_with_nodes'] = True
-    if 'allow_adding_terms' not in config:
-        config['allow_adding_terms'] = False
-    if 'nodes_only' not in config:
-        config['nodes_only'] = False
-    if 'log_request_url' not in config:
-        config['log_request_url'] = False
-    if 'log_json' not in config:
-        config['log_json'] = False
-    if 'log_response_body' not in config:
-        config['log_response_body'] = False
-    if 'log_response_status_code' not in config:
-        config['log_response_status_code'] = False
-    if 'log_headers' not in config:
-        config['log_headers'] = False
-    if 'progress_bar' not in config:
-        config['progress_bar'] = False
-    if 'user_agent' not in config:
-        config['user_agent'] = 'Islandora Workbench'
-    if 'allow_redirects' not in config:
-        config['allow_redirects'] = True
-    if 'secure_ssl_only' not in config:
-        config['secure_ssl_only'] = True
-    if 'google_sheets_csv_filename' not in config:
-        config['google_sheets_csv_filename'] = 'google_sheet.csv'
-    if 'google_sheets_gid' not in config:
-        config['google_sheets_gid'] = '0'
-    if 'excel_worksheet' not in config:
-        config['excel_worksheet'] = 'Sheet1'
-    if 'excel_csv_filename' not in config:
-        config['excel_csv_filename'] = 'excel.csv'
-    if 'ignore_csv_columns' not in config:
-        config['ignore_csv_columns'] = list()
-    if 'use_node_title_for_media' not in config:
-        config['use_node_title_for_media'] = False
-    if 'use_nid_in_media_title' not in config:
-        config['use_nid_in_media_title'] = False
-    if 'field_for_media_title' not in config:
-        config['field_for_media_title'] = False
-    if 'delete_tmp_upload' not in config:
-        config['delete_tmp_upload'] = False
-    if 'list_missing_drupal_fields' not in config:
-        config['list_missing_drupal_fields'] = False
-    if 'secondary_tasks' not in config:
-        config['secondary_tasks'] = None
-    if 'secondary_tasks_data_file' not in config:
-        config['secondary_tasks_data_file'] = 'id_to_node_map.tsv'
-    if 'fixity_algorithm' not in config:
-        config['fixity_algorithm'] = None
-    if 'validate_fixity_during_check' not in config:
-        config['validate_fixity_during_check'] = False
-    if 'output_csv_include_input_csv' not in config:
-        config['output_csv_include_input_csv'] = False
-    if 'timestamp_rollback' not in config:
-        config['timestamp_rollback'] = False
-    if 'enable_http_cache' not in config:
-        config['enable_http_cache'] = True
-    if 'validate_terms_exist' not in config:
-        config['validate_terms_exist'] = True
-    # Used for integration tests only, in which case it will either be True or False.
-    if 'drupal_8' not in config:
-        config['drupal_8'] = None
-
-    if config['task'] == 'create':
-        if 'id_field' not in config:
-            config['id_field'] = 'id'
-    if config['task'] == 'add_media':
-        if 'id_field' not in config:
-            config['id_field'] = 'node_id'
-    if config['task'] == 'create' or config['task'] == 'create_from_files':
-        if 'published' not in config:
-            config['published'] = 1
-
-    if config['task'] == 'create' or config['task'] == 'add_media' or config['task'] == 'create_from_files':
-        if 'preprocessors' in config_data:
-            config['preprocessors'] = {}
-            for preprocessor in config_data['preprocessors']:
-                for key, value in preprocessor.items():
-                    config['preprocessors'][key] = value
-
-        if 'media_types' not in config:
-            config['media_types'] = []
-            image = collections.OrderedDict({'image': ['png', 'gif', 'jpg', 'jpeg']})
-            config['media_types'].append(image)
-            document = collections.OrderedDict({'document': ['pdf', 'doc', 'docx', 'ppt', 'pptx']})
-            config['media_types'].append(document)
-            file = collections.OrderedDict({'file': ['tif', 'tiff', 'jp2', 'zip', 'tar']})
-            config['media_types'].append(file)
-            audio = collections.OrderedDict({'audio': ['mp3', 'wav', 'aac']})
-            config['media_types'].append(audio)
-            video = collections.OrderedDict({'video': ['mp4']})
-            config['media_types'].append(video)
-            extracted_text = collections.OrderedDict({'extracted_text': ['txt']})
-            config['media_types'].append(extracted_text)
-
-        # Set config['media_bundle_file_fields']. If 'media_fields' option is present in
-        # the config file, determine which field to use for the file, per media bundle.
-        # Note that 'media_file_fields' is the option used in the config file, and that
-        # config['media_bundle_file_fields'] is the internal name of the setting.
-        media_fields = dict({
-            'file': 'field_media_file',
-            'document': 'field_media_document',
-            'image': 'field_media_image',
-            'audio': 'field_media_audio_file',
-            'video': 'field_media_video_file',
-            'extracted_text': 'field_media_file',
-            'fits_technical_metadata': 'field_media_file'
-        })
-        if 'media_file_fields' in config:
-            for media_field in config['media_file_fields']:
-                for media_type, media_field in media_field.items():
-                    media_fields[media_type] = media_field
-        else:
-            config['media_fields'] = media_fields
-
-        config['media_bundle_file_fields'] = media_fields
-
-    if config['task'] == 'create':
-        if 'paged_content_sequence_seprator' not in config:
-            config['paged_content_sequence_seprator'] = '-'
-        if 'paged_content_page_content_type' not in config:
-            config['paged_content_page_content_type'] = config['content_type']
-
-    if args.check:
-        config['check'] = True
-    else:
-        config['check'] = False
-
-    if args.get_csv_template:
-        config['get_csv_template'] = True
-    else:
-        config['get_csv_template'] = False
-
-    return config
-
-
 def set_media_type(config, filepath, file_fieldname, csv_row):
     """Using configuration options, determine which media bundle type to use.
        Options are either a single media type or a set of mappings from
@@ -629,6 +409,11 @@ def ping_islandora(config, print_message=True):
         print(message)
 
 
+def ping_content_type(config):
+    url = f"{config['host']}/admin/structure/types/manage/{config['content_type']}"
+    return issue_request(config, 'GET', url).status_code
+
+
 def ping_media_bundle(config, bundle_name):
     """Ping the Media bunlde/type to see if it exists. Return the status code,
        a 200 if it exists or a 404 if it doesn't exist or the Media Type REST resource
@@ -825,6 +610,10 @@ def get_field_definitions(config, entity_type, bundle_type=None):
 def get_entity_fields(config, entity_type, bundle_type):
     """Get all the fields configured on a bundle.
     """
+    if ping_content_type(config) == 404:
+        message = f"Content type '{config['content_type']}' not defined on {config['host']}."
+        logging.error(message)
+        sys.exit('Error: ' + message)
     fields_endpoint = config['host'] + '/entity/entity_form_display/' + \
         entity_type + '.' + bundle_type + '.default?_format=json'
     bundle_type_response = issue_request(config, 'GET', fields_endpoint)
@@ -1527,7 +1316,7 @@ def check_input(config, args):
                     ' is empty; is that intentional?')
                 logging.warning('Page directory ' + dir_path + ' is empty.')
             for page_file_name in page_files:
-                if config['paged_content_sequence_seprator'] not in page_file_name:
+                if config['paged_content_sequence_separator'] not in page_file_name:
                     message = 'Page file ' + os.path.join(
                         dir_path,
                         page_file_name) + ' does not contain a sequence separator (' + config['paged_content_sequence_seprator'] + ').'
@@ -2049,7 +1838,7 @@ def execute_entity_post_task_script(path_to_script, path_to_config_file, http_re
     return result, cmd.returncode
 
 
-def create_file(config, filename, file_fieldname, node_csv_row, node_id = ''):
+def create_file(config, filename, file_fieldname, node_csv_row, node_id):
     """Creates a file in Drupal, which is then referenced by the accompanying media.
            Parameters
            ----------
@@ -2220,7 +2009,6 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
             return False
 
         media_field = config['media_bundle_file_fields'][media_type]
-
         media_name = os.path.basename(filename)
         if config['use_node_title_for_media']:
             if 'title' in node_csv_row:
@@ -2235,8 +2023,6 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
             media_name = f"{node_id}-Original File"
         if config['field_for_media_title']:
             media_name = node_csv_row[config['field_for_media_title']].replace(':', '_')
-
-
         media_json = {
             "bundle": [{
                 "target_id": media_type,
@@ -4039,14 +3825,14 @@ def create_children_from_directory(config, parent_csv_record, parent_node_id, pa
     # id, and a config-defined Islandora model. Content type and status are inherited
     # as is from parent. The weight assigned to the page is the last segment in the filename,
     # split from the rest of the filename using the character defined in the
-    # 'paged_content_sequence_seprator' config option.
+    # 'paged_content_sequence_separator' config option.
     parent_id = parent_csv_record[config['id_field']]
     page_dir_path = os.path.join(config['input_dir'], parent_id)
     page_files = os.listdir(page_dir_path)
     page_file_return_dict = dict()
     for page_file_name in page_files:
         filename_without_extension = os.path.splitext(page_file_name)[0]
-        filename_segments = filename_without_extension.split(config['paged_content_sequence_seprator'])
+        filename_segments = filename_without_extension.split(config['paged_content_sequence_separator'])
         weight = filename_segments[-1]
         weight = weight.lstrip("0")
         # @todo: come up with a templated way to generate the page_identifier,
@@ -4385,13 +4171,14 @@ def get_prepocessed_file_path(config, file_fieldname, node_csv_row, node_id):
             extension = os.path.splitext(sections.path)[1]
             filename = sections.path.split("/")[-1]
             downloaded_file_path = os.path.join(subdir, filename)
+
         if config['field_for_media_title']:
-            filename =node_csv_row[config['field_for_media_title']]
-            downloaded_file_path = os.path.join(subdir, filename)
-        if config['use_nid_in_media_title']:
-            filename = f"Original File-{node_id}"
+            filename = node_csv_row[config['field_for_media_title']]
             downloaded_file_path = os.path.join(subdir, filename)
 
+        if config['use_nid_in_media_title']:
+            filename = f"{node_id}-Original File"
+            downloaded_file_path = os.path.join(subdir, filename)
 
         if extension == '':
             try:

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -2049,7 +2049,7 @@ def execute_entity_post_task_script(path_to_script, path_to_config_file, http_re
     return result, cmd.returncode
 
 
-def create_file(config, filename, file_fieldname, node_csv_row):
+def create_file(config, filename, file_fieldname, node_csv_row, node_id = ''):
     """Creates a file in Drupal, which is then referenced by the accompanying media.
            Parameters
            ----------
@@ -2085,7 +2085,7 @@ def create_file(config, filename, file_fieldname, node_csv_row):
             return False
 
         filename_parts = urllib.parse.urlparse(filename)
-        file_path = download_remote_file(config, filename, file_fieldname, node_csv_row)
+        file_path = download_remote_file(config, filename, file_fieldname, node_csv_row, node_id)
         if file_path is False:
             return False
         filename = file_path.split("/")[-1]
@@ -2187,11 +2187,11 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
     if config['nodes_only'] is True:
         return
 
-    file_result = create_file(config, filename, file_fieldname, node_csv_row)
+    file_result = create_file(config, filename, file_fieldname, node_csv_row, node_id)
     if filename.startswith('http'):
         if file_result is False:
             return False
-        filename = get_prepocessed_file_path(config, file_fieldname, node_csv_row)
+        filename = get_prepocessed_file_path(config, file_fieldname, node_csv_row, node_id)
     if isinstance(file_result, int):
         if 'media_use_tid' in node_csv_row and len(node_csv_row['media_use_tid']) > 0:
             media_use_tid_value = node_csv_row['media_use_tid']
@@ -2232,7 +2232,7 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
                     logging.warning(message)
                     media_name = os.path.basename(filename)
         if config['use_nid_in_media_title']:
-            media_name = f"{node_id}-Original"
+            media_name = f"{node_id}-Original File"
         if config['field_for_media_title']:
             media_name = node_csv_row[config['field_for_media_title']].replace(':', '_')
 
@@ -4335,7 +4335,7 @@ def check_file_exists(config, filename):
             return True
 
 
-def get_prepocessed_file_path(config, file_fieldname, node_csv_row):
+def get_prepocessed_file_path(config, file_fieldname, node_csv_row, node_id):
     """For remote/downloaded files, generates the path to the local temporary
        copy and returns that path. For local files, just returns the value of
        node_csv_row['file'].
@@ -4388,6 +4388,9 @@ def get_prepocessed_file_path(config, file_fieldname, node_csv_row):
         if config['field_for_media_title']:
             filename =node_csv_row[config['field_for_media_title']]
             downloaded_file_path = os.path.join(subdir, filename)
+        if config['use_nid_in_media_title']:
+            filename = f"Original File-{node_id}"
+            downloaded_file_path = os.path.join(subdir, filename)
 
 
         if extension == '':
@@ -4421,7 +4424,7 @@ def get_prepocessed_file_path(config, file_fieldname, node_csv_row):
         return file_path
 
 
-def download_remote_file(config, url, file_fieldname, node_csv_row):
+def download_remote_file(config, url, file_fieldname, node_csv_row, node_id):
     sections = urllib.parse.urlparse(url)
     try:
         response = requests.get(url, allow_redirects=True, verify=config['secure_ssl_only'])
@@ -4440,7 +4443,7 @@ def download_remote_file(config, url, file_fieldname, node_csv_row):
         print('Error: ' + message)
         return False
 
-    downloaded_file_path = get_prepocessed_file_path(config, file_fieldname, node_csv_row)
+    downloaded_file_path = get_prepocessed_file_path(config, file_fieldname, node_csv_row, node_id)
 
     f = open(downloaded_file_path, 'wb+')
     f.write(response.content)


### PR DESCRIPTION
## Link to Github issue or other discussions

>  [Issue 374 - Alternate media naming strategies](https://github.com/mjordan/islandora_workbench/issues/374)
## What does this PR do?

> Allows users to name media and associated files either by node_id or any field in the input csv

## What changes were made?

> Two new configuration options were added, plus a validation to ensure that conflicting options were not chosen.

## How to test / verify this PR?

> Add `use_nid_in_media_title: 1` to test confg file.  Resulting media should be called <nid>-Original File
Add `field_for_media_title: <some unique field>` to test config without removing `use_nid_in_media_title: 1`
Job should fail with a meaningful message.
Remove `use_nid_in_media_title: 1` - Job should run successfully with media named for whatever field was specified
## Interested Parties

>  @mjordan, @dara

---

## Checklist

* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
