### PR TITLE
Firmed up datastream selection

### DIFF
--- a/i7Import/get_islandora_7_content.py
+++ b/i7Import/get_islandora_7_content.py
@@ -87,6 +87,7 @@ with open(config['csv_output_path'], 'w', newline='') as csvfile:
             for key, value in rels_ext.items():
                 if 'isSequenceNumber' in key:
                     row['sequence'] = str(value)
+            content_model = rels_ext.get('hasModel')
         else:
             failed_pids.append(row['PID'])
             logging.error(f"{row['PID']} was unsuccessful.")
@@ -95,11 +96,14 @@ with open(config['csv_output_path'], 'w', newline='') as csvfile:
             row_count += 1
             row_position = utils.get_percentage(row_count, num_csv_rows)
             pbar(row_position)
-            for datastream in config['datastreams']:
-                file = utils.get_i7_asset(row['PID'], datastream)
-                if file:
-                    row['file'] = file
-                    break
+            datastream = 'OBJ'
+            if content_model == 'islandora:sp_pdf':
+                datastream = 'PDF'
+            if config['datastreams'].get(content_model):
+                datastream = config['datastreams'][content_model]
+            file = utils.get_i7_asset(row['PID'], datastream)
+            if file:
+                row['file'] = file
 
         if config['id_field'] in headers:
             row[config['id_field']] = index + reader.line_num - 2

--- a/i7Import/i7ImportUtilities.py
+++ b/i7Import/i7ImportUtilities.py
@@ -40,7 +40,7 @@ class i7ImportUtilities:
         'field_pattern_do_not_want': '(marcrelator|isSequenceNumberOf)',
         'id_field': 'PID',
         'id_start_number': 1,
-        'datastreams': ['OBJ', 'PDF'],
+        'datastreams': False,
         'debug': False,
         'deep_debug': False,
         'collection': False,
@@ -168,6 +168,9 @@ class i7ImportUtilities:
                 obj_download_response = requests.head(url=obj_url, allow_redirects=True)
             else:
                 obj_download_response = requests.get(url=obj_url, allow_redirects=True)
+            if obj_download_response.status_code != 200:
+                logging.warning(f"{obj_url} not found.")
+
             if obj_download_response.status_code == 200:
                 # Get MIMETYPE from 'Content-Type' header
                 obj_mimetype = obj_download_response.headers['content-type']
@@ -179,6 +182,7 @@ class i7ImportUtilities:
                     obj_file_path = os.path.join(self.config['obj_directory'], obj_basename)
                     open(obj_file_path, 'wb+').write(obj_download_response.content)
                     return obj_basename
+
 
                 if self.config['get_file_url'] and obj_extension:
                     return obj_url

--- a/i7Import/i7ImportUtilities.py
+++ b/i7Import/i7ImportUtilities.py
@@ -40,7 +40,7 @@ class i7ImportUtilities:
         'field_pattern_do_not_want': '(marcrelator|isSequenceNumberOf)',
         'id_field': 'PID',
         'id_start_number': 1,
-        'datastreams': False,
+        'datastreams': {},
         'debug': False,
         'deep_debug': False,
         'collection': False,


### PR DESCRIPTION
## Link to Github issue or other discussion

> [Firm Up datastream selection](https://github.com/mjordan/islandora_workbench/issues/389)

## What does this PR do?

> Ensures you get the correct datastream per content type

## What changes were made?

> Made datastream selection dependent on content type
## How to test/verify this PR?

> Run against any repository and see that PDFs are returned on objects with that content type, and OBJs on anything else.  Next add 
```
datastreams:
   islandora:sp_pdf: 'MODS'
   fictional: "thumbnail"
```
to your config and check to see that the MODS datastream is harvested.

## Interested Parties

 @mjordan_

---

## Checklist

* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an addiional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
