### PR TITLE
Additional Files fixes

### DIFF
--- a/workbench
+++ b/workbench
@@ -283,39 +283,41 @@ def create():
                     if config['progress_bar'] is False:
                         print("- ERROR: Media for " + row['file'] + " not created. See log for more information.")
                     logging.error("Media for %s not created (HTTP respone code %s).", row['file'], media_response_status_code)
-                if 'additional_files' in config:
-                    additional_files_config = get_additional_files_config(config)
-                    if len(additional_files_config) > 0:
-                        for additional_file_field, additional_file_media_use_tid in additional_files_config.items():
-                            # If there is no additional media file, move on to the next "additional_files" column.
-                            if config['nodes_only'] is False and additional_file_field in row and len(row[additional_file_field].strip()) == 0:
-                                if config['progress_bar'] is False:
-                                    print('- No media for ' + node_uri + ' created since its "' + additional_file_field + '" field in the CSV is empty.')
-                                logging.warning("No media for %s created since its '%s' field in the CSV is empty.", node_uri, additional_file_field)
-                                continue
-                                file_exists = check_file_exists(config, filename)
-                                if file_exists is False:
-                                    if config['progress_bar'] is False:
-                                        print('- No media for ' + node_uri + ' created since its "' + additional_file_field + '" field in the CSV is empty.')
-                                    logging.warning("No media for %s created since its '%s' field in the CSV is empty.", node_uri, additional_file_field)
-                                    continue
-                            if drupal_8 is True:
-                                media_response_status_code = create_islandora_media(config, row[additional_file_field], additional_file_field, node_uri, row_for_media, additional_file_media_use_tid)
-                            else:
-                                media_response_status_code = create_media(config, row[additional_file_field], additional_file_field, node_nid, row_for_media, additional_file_media_use_tid)
-                            if media_response_status_code in allowed_media_response_codes:
-                                if config['progress_bar'] is False:
-                                    print("+ Media for " + row[additional_file_field] + " created.")
-                                logging.info("Media for %s created.", row[additional_file_field])
-                            else:
-                                if config['progress_bar'] is False:
-                                    print("- Media for " + row[additional_file_field] + " not created. See log for more information.")
-                                logging.error("Media for %s not created (HTTP respone code %s).", row[additional_file_field], media_response_status_code)
 
-            if config['nodes_only'] is False and 'file' in row and len(row['file']) == 0 and config['paged_content_from_directories'] is False:
+            if config['nodes_only'] is False and 'additional_files' in config:
+                additional_files_config = get_additional_files_config(config)
+                if len(additional_files_config) > 0:
+                    for additional_file_field, additional_file_media_use_tid in additional_files_config.items():
+                        # If there is no additional media file, move on to the next "additional_files" column.
+                        if additional_file_field in row and len(row[additional_file_field].strip()) == 0:
+                            if config['progress_bar'] is False:
+                                print("- Skipping empty additional_media CSV field '{field}' for {uri}.".format(field=additional_file_field, uri=node_uri))
+                            logging.warning("- Skipping empty additional_media CSV field '%s' for %s.", node_uri, additional_file_field)
+                            continue
+                        filename = row[additional_file_field].strip()
+                        file_exists = check_file_exists(config, filename)
+                        if file_exists is False:
+                            if config['progress_bar'] is False:
+                                print("- WARNING: File '{file}' from additional_media CSV field '{field}' for {uri} does not exist.".format(file=filename, field=additional_file_field, uri=node_uri))
+                            logging.warning("File '%s' from additional_media CSV field '%s' for %s does not exist.", filename, node_uri, additional_file_field)
+                            continue
+                        if drupal_8 is True:
+                            media_response_status_code = create_islandora_media(config, row[additional_file_field], additional_file_field, node_uri, row_for_media, additional_file_media_use_tid)
+                        else:
+                            media_response_status_code = create_media(config, row[additional_file_field], additional_file_field, node_nid, row_for_media, additional_file_media_use_tid)
+                        if media_response_status_code in allowed_media_response_codes:
+                            if config['progress_bar'] is False:
+                                print("+ Media for " + row[additional_file_field] + " created.")
+                            logging.info("Media for %s created.", row[additional_file_field])
+                        else:
+                            if config['progress_bar'] is False:
+                                print("- Media for " + row[additional_file_field] + " not created. See log for more information.")
+                            logging.error("Media for %s not created (HTTP respone code %s).", row[additional_file_field], media_response_status_code)
+
+            if config['nodes_only'] is False and 'file' in row and len(row['file']) == 0 and 'additional_files' not in config and config['paged_content_from_directories'] is False:
                 if config['progress_bar'] is False:
-                    print('+ No file specified in CSV for row ' + str(id_field))
-                logging.info("No file specified for row %s, so no media created.", str(id_field))
+                    print('+ No files specified in CSV for row ' + str(id_field))
+                logging.info("No files specified for row %s, so no media created.", str(id_field))
 
             if config['paged_content_from_directories'] is True:
                 # Console output and logging are done in the create_children_from_directory() function.
@@ -951,7 +953,7 @@ def export_csv():
                     csv_data = serialize_field_json(config, field_definitions, fieldname_to_serialize, body[fieldname_to_serialize])
                     output_row[fieldname_to_serialize] = csv_data
         else:
-            message = f'Attempt to get node {node_id} returned a {response.status_code} status code.'
+            message = f"Attempt to get node {row['node_id']} returned a {response.status_code} status code."
             print("  Error: " + message)
             logging.warning(message)
             return False
@@ -1048,7 +1050,7 @@ def get_data_from_view():
         else:
             message = "Node with ID " + node['nid']['value'] + " not written to output CVS because its content type (" + \
                 node['type'][0]['target_id'] + ") is not the same as the 'content_type' configuration option."
-            info.warning(message)
+            logging.info.warning(message)
             continue
 
     # Loop through the remaining pages, until we encounter an empty page.
@@ -1074,7 +1076,7 @@ def get_data_from_view():
             else:
                 message = "Node with ID " + node['nid']['value'] + " not written to output CVS because its content type (" + \
                     node['type'][0]['target_id'] + ") is not the same as the 'content_type' configuration option."
-                info.warning(message)
+                logging.info.warning(message)
                 continue
 
     csv_file.close()

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -1343,7 +1343,7 @@ def check_input(config, args):
             # Check for empty 'file' values.
             if len(file_check_row['file']) == 0:
                 message = 'CSV row with ID ' + file_check_row[config['id_field']] + ' contains an empty "file" value.'
-                if config['exit_on_first_missing_file_during_check'] is True:
+                if config['exit_on_first_missing_file_during_check'] is True and config['allow_missing_files'] is False:
                     logging.error(message)
                     sys.exit('Error: ' + message)
                 else:
@@ -1356,7 +1356,7 @@ def check_input(config, args):
                 if http_response_code != 200 or ping_remote_file(config, file_check_row['file']) is False:
                     message = 'Remote file "' + file_check_row['file'] + '" identified in CSV "file" column for record with ID "' \
                         + file_check_row[config['id_field']] + '" not found or not accessible (HTTP response code ' + str(http_response_code) + ').'
-                    if config['exit_on_first_missing_file_during_check'] is True:
+                    if config['exit_on_first_missing_file_during_check'] is True and config['allow_missing_files'] is False:
                         logging.error(message)
                         sys.exit('Error: ' + message)
                     else:
@@ -1657,7 +1657,7 @@ def check_input_for_create_from_files(config, args):
     for option in unwanted_in_create_from_files:
         if option in config_keys:
             config_keys.remove(option)
-
+    joiner = ', '
     # Check for presence of required config keys.
     create_required_options = [
         'task',
@@ -1666,7 +1666,7 @@ def check_input_for_create_from_files(config, args):
         'password']
     for create_required_option in create_required_options:
         if create_required_option not in config_keys:
-            message = 'Please check your config file for required values: ' + joiner.join(create_options) + '.'
+            message = 'Please check your config file for required values: ' + joiner.join(create_required_options) + '.'
             logging.error(message)
             sys.exit('Error: ' + message)
 
@@ -2244,7 +2244,7 @@ def create_media(config, filename, file_fieldname, node_id, node_csv_row, media_
         media_type = set_media_type(config, filename, file_fieldname, node_csv_row)
         media_bundle_response_code = ping_media_bundle(config, media_type)
         if media_bundle_response_code == 404:
-            message = 'File "' + file_check_row[filename_field] + '" identified in CSV row ' + file_check_row[config['id_field']] + \
+            message = 'File "' + filename + '" identified in CSV row ' + file_fieldname + \
                 ' will create a media of type (' + media_type + '), but that media type is not configured in the destination Drupal.'
             logging.error(message)
             return False
@@ -2365,7 +2365,7 @@ def create_islandora_media(config, filename, file_fieldname, node_uri, node_csv_
     media_type = set_media_type(config, filename, file_fieldname, node_csv_row)
     media_bundle_response_code = ping_media_bundle(config, media_type)
     if media_bundle_response_code == 404:
-        message = 'File "' + file_check_row[filename_field] + '" identified in CSV row ' + file_check_row[config['id_field']] + \
+        message = 'File "' + filename + '" identified in CSV row ' + file_fieldname + \
             ' will create a media of type (' + media_type + '), but that media type is not configured in the destination Drupal.'
         logging.error(message)
         return False


### PR DESCRIPTION
## Link to Github issue or other discussion

#310 & #434

## What does this PR do?

Adds fixes for the `allow_missing_files: true` and `additional_files` to work as expected.

## What changes were made?

- Shifts the `additional_files` check out of the `files` check so it can be run alone.
- Adds two `allow_missing_files` to the `--check` so it doesn't fail early.
- Clean-up some issues identified by my IDE.

## How to test / verify this PR?

Set up a create task config similar to
```yml
task: create
host: "http://dams.library.unlv.edu"
username: REDACTED
password: 'REDACTED'
input_dir: 'O:\digitalworkspace\MAN Manuscript Collections'
input_csv: MS-00169.csv 
allow_missing_files: true
content_type: dc_object
id_field: field_digital_id
additional_files:
    - service: 139
```
where some rows are missing any file references and some rows have no file path in the file field but a file path in the additional_files column.

Running a check without the PR will end early. Running the task will result in files being created but not the additional files for those rows without a file path in the file column.

Apply the PR.

Run a check and see it complete. Then run the task and see _all_ the media be created.

## Interested Parties

@mjordan & @dara2

---

## Checklist

* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
