### PR TITLE
Issue #436: add view_parameters config for get_data_from_view

### DIFF
--- a/workbench
+++ b/workbench
@@ -990,7 +990,8 @@ def get_data_from_view():
     print(message)
     logging.info(message)
 
-    view_url = config['host'] + '/' + config['view_path'].lstrip('/')
+    view_parameters =  '&'.join(config['view_parameters']) if 'view_parameters' in config else ''
+    view_url = config['host'] + '/' + config['view_path'].lstrip('/') + '?page=0&' + view_parameters
     view_path_status_code = ping_view_path(config, view_url)
     if view_path_status_code != 200:
         message = f"Cannot access View at {view_url}."
@@ -1030,7 +1031,7 @@ def get_data_from_view():
     view_url = config['host'] + '/' + config['view_path'].lstrip('/') + '?page='
     # Seed the first page of node IDs.
     page = 0
-    url = view_url + str(0)
+    url = view_url + str(0) + '&' + view_parameters
     response = issue_request(config, 'GET', url)
     if response.status_code != 200:
         message = f"Request to View at {url} returned a non-200 status ({response.status_code})."
@@ -1056,7 +1057,7 @@ def get_data_from_view():
     # Loop through the remaining pages, until we encounter an empty page.
     while len(nodes) > 0:
         page += 1
-        url = view_url + str(page)
+        url = view_url + str(page) + '&' + view_parameters
         response = issue_request(config, 'GET', url)
         if response.status_code != 200:
             message = f"Request to View at {url} returned a non-200 status ({response.status_code}); page {page} of results not written to the output CSV file."


### PR DESCRIPTION
## Link to Github issue or other discussion

#436

## What does this PR do?

This adds the ability to provide view parameters for the get_data_from_view task.

## What changes were made?

Adds a new view_parameters variable to get_data_from_view that will pull from a view_parameters array in the config and then modifies the view_url to incorporate them into each request.

## How to test / verify this PR?

1. Create a REST view and workbench config according to [the instructions](https://mjordan.github.io/islandora_workbench_docs/generating_csv_files/#using-a-drupal-view-to-identify-content-to-export-as-csv). 
2. Add a Filter to the REST view and set it to be exposed. E.g. 
![Capture](https://user-images.githubusercontent.com/29869988/175608210-41b82614-1891-42ce-850f-2b2e95c90466.PNG)
3. Add a view_parameters config that includes a line for the value you want in the exposed filter. E.g.
```yml
view_parameters:
  - 'field_digital_id_value=whh'
```
4. Run the task and note that it pulled in records that match the configured filter.

## Interested Parties

@mjordan