### PR TITLE
Issue 447:  setup.py not working on macOS / Homebrew

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     url="https://github.com/mjordan/islandora_workbench",
     license="The Unlicense",
     install_requires=['requests>=2.22,<3', 'requests_cache', 'iteration_utilities', 'ruamel.yaml', 'progress_bar', 'openpyxl', 'unidecode', 'edtf_validate', 'rich'],
-    python_requires='>=3.7'
+    python_requires='>=3.7',
+    py_modules=[]
 )


### PR DESCRIPTION
Add empty modules list.

## Link to Github issue or other discussion

https://github.com/mjordan/islandora_workbench/issues/447

Issue in other project with resolution : https://github.com/pypa/setuptools/issues/3197#issuecomment-1078770109


## What does this PR do?

Fix setup.py to run on newer versions of Python / setup tools.

## What changes were made?

Add an empty list of modules in setup.py to avoid error about multiple directories.

## How to test / verify this PR?


On macOS Home-brew, the current version is 3.9.13. Clone the repository, and test as per the installation instructions.


## Interested Parties

> _**Replace this text** - name some folks who may be interested, or, if unsure, @mjordan_

---

## Checklist

* [ ]Y Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ N/A] Have you included same configuration and/or CSV files useful for testing this PR?
* [ N/A] Have you written unit or integration tests if applicable?
* [ N/A] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ N/A] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
