### PR TITLE
Changed logging.info.warning to logging.warning

### DIFF
--- a/workbench
+++ b/workbench
@@ -1067,7 +1067,7 @@ def get_data_from_view():
         else:
             message = "Node with ID " + str(node['nid'][0]['value']) + " not written to output CVS because its content type (" + \
                 node['type'][0]['target_id'] + ") is not the same as the 'content_type' configuration option."
-            logging.info.warning(message)
+            logging.warning(message)
             continue
 
     # Loop through the remaining pages, until we encounter an empty page.
@@ -1096,7 +1096,7 @@ def get_data_from_view():
                 else:
                     message = "Node with ID " + str(node['nid'][0]['value']) + " not written to output CVS because its content type (" + \
                         node['type'][0]['target_id'] + ") is not the same as the 'content_type' configuration option."
-                    logging.info.warning(message)
+                    logging.warning(message)
                     continue
 
     csv_file.close()


### PR DESCRIPTION
I noticed two lines that can cause crashes because `logging.info.warning(message)` should have been `logging.warning(message)`.

## Link to Github issue or other discussion

(None)

## What does this PR do?

Bug fix

## What changes were made?

All `logging.info.warning(message)` lines were changed to `logging.warning(message)`.

## How to test / verify this PR?

N/A

## Interested Parties

@mjordan

---

## Checklist

* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
