### PR TITLE
Added rollback_dir configuration option

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -168,6 +168,7 @@ class WorkbenchConfig:
             'validate_fixity_during_check': False,
             'output_csv_include_input_csv': False,
             'timestamp_rollback': False,
+            'rollback_dir': None,
             'enable_http_cache': True,
             'validate_terms_exist': True,
             'validate_parent_node_exists': True,

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -5129,7 +5129,6 @@ def prep_rollback_csv(config, path_to_rollback_csv_file):
         sys.exit('Error: ' + message)
 
 
-
 def write_rollback_node_id(config, node_id, path_to_rollback_csv_file):
     path_to_rollback_csv_file = get_rollback_csv_filepath(config)
     rollback_csv_file = open(path_to_rollback_csv_file, "a+")

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -5094,7 +5094,7 @@ def get_rollback_csv_filepath(config):
         rollback_csv_filename = 'rollback.' + now_string + '.csv'
     else:
         rollback_csv_filename = 'rollback.csv'
-    return os.path.join(config['input_dir'], rollback_csv_filename)
+    return os.path.join(config['rollback_dir'] or config['input_dir'], rollback_csv_filename)
 
 
 def write_rollback_config(config, path_to_rollback_csv_file):

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -5117,12 +5117,17 @@ def write_rollback_config(config, path_to_rollback_csv_file):
 
 
 def prep_rollback_csv(config, path_to_rollback_csv_file):
-    path_to_rollback_csv_file = get_rollback_csv_filepath(config)
-    if os.path.exists(path_to_rollback_csv_file):
-        os.remove(path_to_rollback_csv_file)
-    rollback_csv_file = open(path_to_rollback_csv_file, "a+")
-    rollback_csv_file.write("node_id" + "\n")
-    rollback_csv_file.close()
+    try:
+        if os.path.exists(path_to_rollback_csv_file):
+            os.remove(path_to_rollback_csv_file)
+        rollback_csv_file = open(path_to_rollback_csv_file, "a+")
+        rollback_csv_file.write("node_id" + "\n")
+        rollback_csv_file.close()
+    except Exception as e:
+        message = "Workbench was unable save rollback CSV to " + path_to_rollback_csv_file + "."
+        logging.error(message)
+        sys.exit('Error: ' + message)
+
 
 
 def write_rollback_node_id(config, node_id, path_to_rollback_csv_file):
@@ -5330,7 +5335,7 @@ def get_preprocessed_file_path(config, file_fieldname, node_csv_row, node_id=Non
             if config['task'] == 'add_media':
                 node_csv_row['title'] = get_node_title_from_nid(config, node_csv_row['node_id'])
                 if node_csv_row['title'] is False:
-                    message = 'Cannot access node " + node_id + ", so cannot get its title for use in media filename. Using filename instead.'
+                    message = 'Cannot access node ' + node_id + ', so cannot get its title for use in media filename. Using filename instead.'
                     logging.warning(message)
                     node_csv_row['title'] = os.path.basename(node_csv_row[file_fieldname].strip())
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -5335,7 +5335,7 @@ def get_preprocessed_file_path(config, file_fieldname, node_csv_row, node_id=Non
             if config['task'] == 'add_media':
                 node_csv_row['title'] = get_node_title_from_nid(config, node_csv_row['node_id'])
                 if node_csv_row['title'] is False:
-                    message = 'Cannot access node ' + node_id + ', so cannot get its title for use in media filename. Using filename instead.'
+                    message = 'Cannot access node ' + str(node_id) + ', so cannot get its title for use in media filename. Using filename instead.'
                     logging.warning(message)
                     node_csv_row['title'] = os.path.basename(node_csv_row[file_fieldname].strip())
 


### PR DESCRIPTION
## Link to Github issue or other discussion

(None)

## What does this PR do?

Added a configuration option to specify what directory to store the rollback CSV in. This was created in response to a use case where the `input_dir` only had read permission, but it could have other uses.

## What changes were made?

Added `rollback_dir` as a configuration option. It defaults to `None`, in which `get_rollback_csv_filepath` will use `input_dir` instead, following old behavior.

In addition, it now provides an error message within `prep_rollback_csv` if it fails to write to the rollback CSV for any reason, which should catch majority of rollback file permission issues.

(Plus one bonus bugfix.)

## How to test / verify this PR?

Run a task with an `input_dir` that only has read permissions. Then add a `rollback_dir` with write permissions and run the task again.

## Interested Parties

@mjordan

---

## Checklist

* [x] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [x] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
