### PR TITLE
Pin ruamel.yaml to 0.17.21 or below.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,16 @@ setup(
     description="A command-line tool that allows creation, updating, and deletion of Islandora content.",
     url="https://github.com/mjordan/islandora_workbench",
     license="MIT",
-    install_requires=['requests>=2.22,<3', 'requests_cache', 'ruamel.yaml', 'progress_bar', 'openpyxl', 'unidecode', 'edtf_validate', 'rich'],
-    python_requires='>=3.7',
-    py_modules=[]
+    install_requires=[
+        "requests>=2.22,<3",
+        "requests_cache",
+        "ruamel.yaml<=0.17.21",
+        "progress_bar",
+        "openpyxl",
+        "unidecode",
+        "edtf_validate",
+        "rich",
+    ],
+    python_requires=">=3.7",
+    py_modules=[],
 )


### PR DESCRIPTION
Got burned by [this](https://islandora.slack.com/archives/C01TLCB0EEQ/p1683127763076039) today on a Playbook build. 

@mjordan @rosiel 