### PR TITLE
Changed LinkField to not append %% for empty titles

### DIFF
--- a/workbench_fields.py
+++ b/workbench_fields.py
@@ -757,7 +757,7 @@ class LinkField():
 
         subvalues = list()
         for subvalue in field_data:
-            if 'title' in subvalue and subvalue['title'] is not None:
+            if 'title' in subvalue and subvalue['title'] is not None and subvalue['title'] != '':
                 subvalues.append(subvalue['uri'] + '%%' + subvalue['title'])
             else:
                 subvalues.append(subvalue['uri'])


### PR DESCRIPTION
## Link to Github issue or other discussion

https://github.com/mjordan/islandora_workbench/issues/604

## What does this PR do?

Serialized links will not include `%%` if the `title` field is an empty string.

Most of our Digital Collections objects' permalinks have a null title:
`"field_archival_resource_key":[{"uri":"http:\/\/n2t.net\/ark:\/62930\/d1j09wb2f","title":null,"options":[]}]`,
but for an unknown reason, some of them have an empty title:
`"field_archival_resource_key":[{"uri":"http:\/\/n2t.net\/ark:\/62930\/d1sw7m","title":"","options":[]}]`,
which is then serialized as `http://n2t.net/ark:/62930/d1sw7m%%`.

I figured that it is safe to simply exclude the `%%` in such cases.

## What changes were made?

Added a simple check for empty titles.

## How to test / verify this PR?

Export metadata for some objects with links that have empty titles as well as ones with links that have null titles.

## Interested Parties

@mjordan_

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to do?
* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
