### PR TITLE
Remove default node status property

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -190,7 +190,6 @@ class WorkbenchConfig:
             'enable_http_cache': True,
             'validate_terms_exist': True,
             'validate_parent_node_exists': True,
-            'published': 1,
             'media_types': self.get_media_types(),
             'preprocessors': {},
             'check': self.args.check,

--- a/workbench
+++ b/workbench
@@ -67,7 +67,7 @@ def create():
 
         id_field = row[config['id_field']]
 
-        # Add required fields. 'status' ("published") can be overridden in CSV, below.
+        # Add required fields.
         node = {
             'type': [
                 {'target_id': config['content_type'],
@@ -75,9 +75,6 @@ def create():
             ],
             'title': [
                 {'value': row['title']}
-            ],
-            'status': [
-                {'value': config['published']}
             ]
         }
 
@@ -1290,9 +1287,6 @@ def create_from_files():
             ],
             'title': [
                 {'value': filename_without_extension}
-            ],
-            'status': [
-                {'value': config['published']}
             ]
         }
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -5342,9 +5342,6 @@ def create_children_from_directory(config, parent_csv_record, parent_node_id):
             'title': [
                 {'value': page_title}
             ],
-            'status': [
-                {'value': config['published']}
-            ],
             'field_member_of': [
                 {'target_id': parent_node_id,
                  'target_type': 'node'}


### PR DESCRIPTION
## Link to Github issue or other discussion

#616

## What does this PR do?

No longer adds a default `status` property to nodes. This property causes node creation via REST to fail when the workflows module is enabled.

## What changes were made?

Removed the `status` property from the JSON templates and the published property from the default config.

## How to test / verify this PR?

Use workbench as usual. Does it still create nodes as you would expect? Try enabling the workflows module. Does it still work?

## Interested Parties

@mjordan and @rosiel.

---

## Checklist

* [:heavy_check_mark:] Before opening this PR, have you opened an issue explaining what you want to to do?
* [:heavy_check_mark:] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ N/A ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ N/A ] Have you written unit or integration tests if applicable?
* [ No ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ No ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ N/A ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
