### PR TITLE
Changed file_result comparison

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -3081,9 +3081,8 @@ def create_media(config, filename, file_fieldname, node_id, csv_row, media_use_t
         file_result = create_file(config, filename, file_fieldname, csv_row, node_id)
 
     if filename.startswith('http'):
-        if file_result is False:
-            return False
-        filename = get_preprocessed_file_path(config, file_fieldname, csv_row, node_id, False)
+        if file_result > 0:
+            filename = get_preprocessed_file_path(config, file_fieldname, csv_row, node_id, False)
 
     if isinstance(file_result, int):
         if 'media_use_tid' in csv_row and len(csv_row['media_use_tid']) > 0:


### PR DESCRIPTION
## Link to Github issue or other discussion

> **Issue #252**

## What does this PR do?

> This fixes the issue with remote video media.

## What changes were made?

> Two lines in the create media function where file_results get compared. It now does not change the remote video media url.

## How to test / verify this PR?

> To test you need a remote video file from Youtube or Vimeo. Use the add_media task and include the oembed_provders. The csv file only needs at minimum the node_id and file columns. 

Sample Data:
<!DOCTYPE html>

<html>
<body>

node_id | file
-- | --
14 | https://vimeo.com/video_id_number

</body>
</html>

Sample Configuration File:

task: add_media
host: "https://islandora.traefik.me"
username:
password:
input_dir: remote_video
input_csv: remote_video.csv
oembed_providers:
 \- remote_video: ['https://vimeo.com/', 'https://www.youtube.com/']

## Interested Parties

> _**Replace this text** - name some folks who may be interested, or, if unsure, @mjordan_

---

## Checklist

* [ X ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ X ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ X ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ No ] Have you written unit or integration tests if applicable?
* [ No ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ No ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ N/A ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
