### PR TITLE
Fixed crash in remove_media_and_file when file_id cannot be found

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -3546,7 +3546,7 @@ def remove_media_and_file(config, media_id):
                 logging.error("Media track file %s (from media %s) not deleted (HTTP response code %s).", track_file_id, media_id, track_file_response.status_code)
 
     # Then the media.
-    if file_response.status_code == 204 or file_id is None:
+    if file_id is None or file_response.status_code == 204:
         if config['standalone_media_url'] is True:
             media_endpoint = config['host'] + '/media/' + str(media_id) + '?_format=json'
         else:


### PR DESCRIPTION
## Link to Github issue or other discussion

(None)

## What does this PR do?

Bug fix

## What changes were made?

Swapped order of error checking to avoid a Python `UnboundLocalError`.
(In the case that `file_id` is `None`, the variable `file_response` is never initialized.)

## How to test / verify this PR?

Run a `delete_media` task in which one of the medias fails to find a file_id (I don't know how to easily replicate this).

## Interested Parties

@mjordan_

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included same configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
