### PR TITLE
implementing soft_checks for #620

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -163,7 +163,7 @@ class WorkbenchConfig:
             'allow_missing_files': False,
             # See Issue 620. Allows the "--check" function to keep running past errors that can be handled
             #  well with batch operations, rather than having to fix it in real-time when one error is hit.
-            'perform_soft_checks': True,
+            'perform_soft_checks': False,
             'update_mode': 'replace',
             'max_node_title_length': 255,
             'paged_content_from_directories': False,

--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -161,11 +161,9 @@ class WorkbenchConfig:
             'log_file_path': 'workbench.log',
             'log_file_mode': 'a',
             'allow_missing_files': False,
-            # See issue 268.
-            'strict_check': True,
             # See Issue 620. Allows the "--check" function to keep running past errors that can be handled
             #  well with batch operations, rather than having to fix it in real-time when one error is hit.
-            'perform_soft_checks': False,
+            'perform_soft_checks': True,
             'update_mode': 'replace',
             'max_node_title_length': 255,
             'paged_content_from_directories': False,

--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -163,6 +163,9 @@ class WorkbenchConfig:
             'allow_missing_files': False,
             # See issue 268.
             'strict_check': True,
+            # See Issue 620. Allows the "--check" function to keep running past errors that can be handled
+            #  well with batch operations, rather than having to fix it in real-time when one error is hit.
+            'perform_soft_checks': False,
             'update_mode': 'replace',
             'max_node_title_length': 255,
             'paged_content_from_directories': False,

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -2002,7 +2002,8 @@ def check_input(config, args):
                                 message = 'File "' + file_check_row[filename_field] + '" in CSV row "' + file_check_row[config['id_field']] + \
                                     '" has an extension (' + str(extension) + ') that is not allowed in the "' + media_type_file_field + '" field of the "' + media_type + '" media type.'
                                 logging.error(message)
-                                sys.exit('Error: ' + message)
+                                if config['perform_soft_checks'] is False:
+                                    sys.exit('Error: ' + message)
 
     # Check existence of fields identified in 'additional_files' config setting.
     if (config['task'] == 'create' or config['task'] == 'add_media') and config['nodes_only'] is False and config['paged_content_from_directories'] is False:
@@ -4845,7 +4846,8 @@ def validate_edtf_fields(config, field_definitions, csv_data):
                             if valid is False:
                                 message = 'Value in field "' + field_name + '" in row with ID ' + row[config['id_field']] + ' ("' + field_value + '") is not a valid EDTF date/time.'
                                 logging.error(message)
-                                sys.exit('Error: ' + message)
+                                if config['perform_soft_checks'] is False:
+                                    sys.exit('Error: ' + message)
 
     if edtf_fields_present is True:
         message = "OK, EDTF field values in the CSV file validate."
@@ -4933,7 +4935,8 @@ def validate_parent_ids_precede_children(config, csv_data):
             if row[1]['position'] < positions[parent_id]['position']:
                 message = f"Child item with CSV ID \"{row[0]}\" must come after its parent (CSV ID \"{row[1]['parent_id']}\") in the CSV file."
                 logging.error(message)
-                sys.exit('Error: ' + message)
+                if config['perform_soft_checks'] is False:
+                    sys.exit('Error: ' + message)
 
 
 def validate_parent_ids_in_csv_id_to_node_id_map(config, csv_data):

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -1917,7 +1917,7 @@ def check_input(config, args):
                 # Check for empty 'file' values.
                 if len(file_check_row['file']) == 0:
                     message = 'CSV row with ID ' + file_check_row[config['id_field']] + ' contains an empty "file" value.'
-                    if config['strict_check'] is True and config['allow_missing_files'] is False:
+                    if config['perform_soft_checks'] is False and config['allow_missing_files'] is False:
                         logging.error(message)
                         sys.exit('Error: ' + message)
                     else:
@@ -1930,7 +1930,7 @@ def check_input(config, args):
                     if http_response_code != 200 or ping_remote_file(config, file_check_row['file']) is False:
                         message = 'Remote file "' + file_check_row['file'] + '" identified in CSV "file" column for record with ID "' \
                             + file_check_row[config['id_field']] + '" not found or not accessible (HTTP response code ' + str(http_response_code) + ').'
-                        if config['strict_check'] is True and config['allow_missing_files'] is False:
+                        if config['perform_soft_checks'] is False and config['allow_missing_files'] is False:
                             logging.error(message)
                             sys.exit('Error: ' + message)
                         else:
@@ -1946,7 +1946,7 @@ def check_input(config, args):
                     if not os.path.exists(file_path) or not os.path.isfile(file_path):
                         message = 'File "' + file_path + '" identified in CSV "file" column for record with ID field value "' \
                             + file_check_row[config['id_field']] + '" not found.'
-                        if config['strict_check'] is True:
+                        if config['perform_soft_checks'] is False:
                             logging.error(message)
                             sys.exit('Error: ' + message)
                         else:
@@ -1955,7 +1955,7 @@ def check_input(config, args):
                                 logging.error(message)
 
             # @todo for issue 268: All accumulator variables like 'rows_with_missing_files' should be checked at end of
-            # check_input() (to work with strict_check: false) in addition to at place of check (to work wit strict_check: true).
+            # check_input() (to work with perform_soft_checks: True) in addition to at place of check (to work wit perform_soft_checks: False).
             if len(rows_with_missing_files) > 0:
                 if config['allow_missing_files'] is True:
                     message = 'OK, missing or empty CSV "file" column values detected, but the "allow_missing_files" configuration setting is enabled.'
@@ -2238,7 +2238,7 @@ def check_input(config, args):
             sys.exit('Error: ' + message)
 
     # @todo issue 268: All checks for accumulator variables like 'rows_with_missing_files' should go here.
-    if len(rows_with_missing_files) > 0 and config['strict_check'] is False:
+    if len(rows_with_missing_files) > 0 and config['perform_soft_checks'] is True:
         if config['allow_missing_files'] is False:
             logging.error('Missing or empty CSV "file" column values detected. See log entries above.')
             # @todo issue 268: Only exit if one or more of the checks have failed (i.e. do not exit on each check).

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -1417,6 +1417,8 @@ def check_input(config, args):
 
         # If nothing has failed by now, exit with a positive, upbeat message.
         print("Configuration and input data appear to be valid.")
+        if config['perform_soft_checks'] is True:
+            print('Warning: "perform_soft_checks" is enabled so you need to review your log for errors despite the "OK" reports above.')
         logging.info('Configuration checked for "%s" task using config file "%s", no problems found.', config['task'], args.config)
         sys.exit()
 


### PR DESCRIPTION
## Link to Github issue or other discussion

Solution for https://github.com/mjordan/islandora_workbench/issues/620
Refactors work in progress from #268 to use new `perform_soft_checks` variable

## What does this PR do?

Allows `soft_checks` for `--check` errors that should really be handled in batches, rather than having the check fail on every instance. Initial implementation includes:
* Parent/child order issues
* File extension checks
* EDTF date validation

And it refactors the old `strict_check` to now use `perform_soft_checks`. The logic for variable checking has been reversed, since semantically the two config variables mean the opposite.

## What changes were made?

* Added a new config `'perform_soft_checks': True`
* Added three uses of that variable to allow skipping `exit` functions 
* Refactors `strict_check` to `perform_soft_checks`

## How to test / verify this PR?

* Check out this branch and run a test ingest which includes the three described error types. You should get log messages but your `--check` run should not stop and it should behave like it did with `strict_check` being false.
* On this branch, change `'perform_soft_checks': True,` to `'perform_soft_checks': False,` and run a test ingest which includes the three described error types. You should get the `strict_check` true behavior. 

## Interested Parties

@mjordan, @McFateM, @dara2 
