### PR TITLE
Discard expired cache items for #632

### DIFF
--- a/workbench
+++ b/workbench
@@ -75,6 +75,9 @@ def create():
 
     row_count = 0
     for row in csv_data:
+        # Delete expired items from request_cache before processing a row
+        requests_cache.delete(expired=True)
+
         # Create a copy of the current item's row to pass to create_media().
         row_for_media = copy.deepcopy(row)
         if config['paged_content_from_directories'] is True:


### PR DESCRIPTION
## Link to Github issue or other discussion

[> _**Replace this text** - Provide links to any Github issues or other discussions that are related to this work._](https://github.com/mjordan/islandora_workbench/issues/632)

## What does this PR do?

* For every CSV row loop in the CREATE function, discard expired request_cache items

## How to test / verify this PR?

* Run a CREATE test for longer than 20 minutes. Then query the sqlite cache to verify that only 20 minutes of items are present:
```bash
sqlite3 http_cache.sqlite
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite>SELECT * from responses order by expires ASC limit 10;
2e89a6981d65e27e|��|1690394636
40ed67cb3d6afcd5|��v|1690394639
9deebd737de52d70|��|1690394672
ffbb07330c5ba7d4|��}|1690394674
970c88eddc614ec7|��|1690394722
c532b06b9621b7e2|��x|1690394725
3274064b883157e3|��|1690394760
98c0dca5c8c2c490|��t|1690394763
83def373bafa3a68|��|1690394801
2cb948153ff80680|��r|1690394804
sqlite> SELECT * from responses order by expires DESC limit 10;
5c14b37c293b5146|��}|1690395836
92e42bc8c617bbfc|���|1690395802
2d21d1f7ccea3530|��|1690395799
9f7737709c84b05a|��[|1690395741
e4dafb4d33fee816|���|1690395740
3496c70ebafe5bb9|��|1690395740
9d9ca3d6ac6c2ace|���|1690395700
125c0a4be96627d2|��|1690395696
7002b5ca8f43782b|��}|1690395657
aad6d0d5f3e77c6f|��|1690395653
```

Wed Jul 26 2023 18:03:56 GMT+0000
Wed Jul 26 2023 18:23:56 GMT+0000

20 minutes exactly!

## Interested Parties

@dara2, @mjordan 

