### PR TITLE
Remove mutable params

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -169,10 +169,10 @@ def issue_request(
         config,
         method,
         path,
-        headers=dict(),
+        headers=None,
         json='',
         data='',
-        query={}):
+        query=None):
     """Issue the HTTP request to Drupal. Note: calls to non-Drupal URLs
        do not use this function.
     """
@@ -309,6 +309,12 @@ def issue_request(
         logging.info(response_time_trend_entry)
         # Set this config option back to what it was before we updated in above.
         config['log_response_time'] = log_response_time_value
+
+    if headers is None:
+        headers = dict()
+
+    if query is None:
+        query = dict()
 
     return response
 
@@ -6001,7 +6007,7 @@ def get_preprocessed_file_path(config, file_fieldname, node_csv_row, node_id=Non
         return file_path
 
 
-def get_node_media_ids(config, node_id, media_use_tids=[]):
+def get_node_media_ids(config, node_id, media_use_tids=None):
     """Gets a list of media IDs for a node.
     """
     """Parameters
@@ -6019,6 +6025,9 @@ def get_node_media_ids(config, node_id, media_use_tids=[]):
         list
             List of media IDs.
     """
+    if media_use_tids is None:
+        media_use_tids = []
+
     media_id_list = list()
     url = f"{config['host']}/node/{node_id}/media?_format=json"
     response = issue_request(config, 'GET', url)
@@ -7147,7 +7156,7 @@ def populate_csv_id_to_node_id_map(config, parent_csv_row_id, parent_node_id, cs
 def get_term_field_values(config, term_id):
     """Get a term's field data so we can use it during PATCH updates,
        which replace a field's values.
-    """
+    """.
     url = config['host'] + '/taxonomy/term/' + term_id + '?_format=json'
     response = issue_request(config, 'GET', url)
     term_fields = json.loads(response.text)

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -186,6 +186,12 @@ def issue_request(
         if 'pause' in config and method in ['POST', 'PUT', 'PATCH', 'DELETE'] and value_is_numeric(config['pause']):
             time.sleep(int(config['pause']))
 
+    if headers is None:
+        headers = dict()
+
+    if query is None:
+        query = dict()
+
     headers.update({'User-Agent': config['user_agent']})
 
     # The trailing / is stripped in config, but we do it here too, just in case.
@@ -309,12 +315,6 @@ def issue_request(
         logging.info(response_time_trend_entry)
         # Set this config option back to what it was before we updated in above.
         config['log_response_time'] = log_response_time_value
-
-    if headers is None:
-        headers = dict()
-
-    if query is None:
-        query = dict()
 
     return response
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -7156,7 +7156,7 @@ def populate_csv_id_to_node_id_map(config, parent_csv_row_id, parent_node_id, cs
 def get_term_field_values(config, term_id):
     """Get a term's field data so we can use it during PATCH updates,
        which replace a field's values.
-    """.
+    """
     url = config['host'] + '/taxonomy/term/' + term_id + '?_format=json'
     response = issue_request(config, 'GET', url)
     term_fields = json.loads(response.text)


### PR DESCRIPTION
## Link to Github issue or other discussion

#657 

## What does this PR do?

Switching to a python best practice of not using mutable types in default function params

## What changes were made?

The function params with mutable default values were set to `None`, then inside the function body the params/variables were properly set with their respective mutable type. 

## How to test / verify this PR?

Run some workbench tasks that send REST calls to Drupal to see if the change works.

## Interested Parties

@mjordan_

---

## Checklist

* [ x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ x] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
