### PR TITLE
Convert int to string to avoid errors with requests

### DIFF
--- a/workbench
+++ b/workbench
@@ -1930,7 +1930,7 @@ def update_terms():
             requests_cache.delete(expired=True)
 
         if not value_is_numeric(row['term_id']):
-            row['term_id'] = find_term_in_vocab(config, config['vocab_id'], row['term_id'])
+            row['term_id'] = str(find_term_in_vocab(config, config['vocab_id'], row['term_id']))
         term_ping_result = ping_term(config, row['term_id'])
         url = config['host'] + '/taxonomy/term/' + str(row['term_id']) + '?_format=json'
         term_response = issue_request(config, method.upper(), url)

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -832,6 +832,10 @@ def get_field_definitions(config, entity_type, bundle_type=None):
             field_definitions[fieldname]['entity_type'] = field_config['entity_type']
             field_definitions[fieldname]['required'] = field_config['required']
             field_definitions[fieldname]['label'] = field_config['label']
+            raw_vocabularies = [x for x in field_config['dependencies']['config'] if re.match("^taxonomy.vocabulary.", x)]
+            if len(raw_vocabularies) > 0:
+                vocabularies = [x.replace("taxonomy.vocabulary.", '') for x in raw_vocabularies]
+                field_definitions[fieldname]['vocabularies'] = vocabularies
             # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
             if 'handler' in field_config['settings']:
                 field_definitions[fieldname]['handler'] = field_config['settings']['handler']


### PR DESCRIPTION
## Link to Github issue or other discussion

> [Issue #661](https://github.com/mjordan/islandora_workbench/issues/661)

## What does this PR do?

> Fixes string literal error for term_id in update_terms.

## What changes were made?

> Converts int returned by find_term_in_vocab to a string. This was causing errors in the requests because an int was being used in string concatenations.

## How to test / verify this PR?

> <blockquote>
<p dir="auto">To test, you need a csv file with term_id. All other columns are the same as what you would use for create_terms, however, term_name is not used as a lookup value for the term id and only used if you want to change the term name. To change the parent reference to root, value must be 0. The configuration file needs the task update_terms and vocab_id. The term_id and parent can either be string or numeric. The sample data below updates Notated movement term''s reference from Notated music to Mixed Material in the resource types vocabulary.</p>
</blockquote>



<p dir="auto">Sample Data:</p>


term_id | parent
-- | -- 
Notated movement | Mixed Material




<p dir="auto">Sample Configuration File:</p>
<p dir="auto">task: update_terms<br>
host: "<a href="https://islandora.traefik.me" rel="nofollow">https://islandora.traefik.me</a>"<br>
username:<br>
password:<br>
input_dir: update<br>
input_csv: update.csv<br>
vocab_id: resource_types</p>

## Interested Parties

> _**Replace this text** - name some folks who may be interested, or, if unsure, @mjordan_

---

## Checklist

* [ X ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ X ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ X ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ No ] Have you written unit or integration tests if applicable?
* [ No ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ NA ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ NA ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
