### PR TITLE
Export entity reference fields properly.

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -6788,7 +6788,7 @@ def serialize_field_json(config, field_definitions, field_name, field_data):
         serialized_field = workbench_fields.EntityReferenceField()
         csv_field_data = serialized_field.serialize(config, field_definitions, field_name, field_data)
     # Entity reference revision fields (mostly paragraphs).
-    if field_definitions[field_name]['field_type'] == 'entity_reference_revisions':
+    elif field_definitions[field_name]['field_type'] == 'entity_reference_revisions':
         serialized_field = workbench_fields.EntityReferenceRevisionsField()
         csv_field_data = serialized_field.serialize(config, field_definitions, field_name, field_data)
     # Typed relation fields (currently, only taxonomy term)


### PR DESCRIPTION
## Link to Github issue or other discussion

* #682 

## What does this PR do?

Entity reference fields were getting overridden by their "Simple Field" values. This stops doing that.

## What changes were made?

'if' -> 'elif' 

## How to test / verify this PR?

Before this PR: replicate the bug in #682 
With this PR: terms (and other entities) are exported as values (id or name) in the export spreadsheet.

## Interested Parties

@mjordan 
---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
