### PR TITLE
First attempt at adding unit tests to WorkbenchConfig.py [WIP]

### DIFF
--- a/tests/assets/WorkbenchConfig_test/config_01_create_short_valid.yml
+++ b/tests/assets/WorkbenchConfig_test/config_01_create_short_valid.yml
@@ -1,0 +1,4 @@
+task: create
+host: https://islandora.traefik.me
+username: admin
+password: password

--- a/tests/assets/WorkbenchConfig_test/config_02_01_create_short_invalid.yml
+++ b/tests/assets/WorkbenchConfig_test/config_02_01_create_short_invalid.yml
@@ -1,0 +1,5 @@
+task: create
+host: https://islandora.traefik.me
+username: admin
+password: password
+content_type: invalid_content_type

--- a/tests/assets/WorkbenchConfig_test/config_02_02_create_short_invalid.yml
+++ b/tests/assets/WorkbenchConfig_test/config_02_02_create_short_invalid.yml
@@ -1,0 +1,6 @@
+task: create
+host: https://islandora.traefik.me
+username: admin
+password: password
+use_node_title_for_media: true
+use_nid_in_media_title: true

--- a/tests/assets/WorkbenchConfig_test/config_02_03_create_short_invalid.yml
+++ b/tests/assets/WorkbenchConfig_test/config_02_03_create_short_invalid.yml
@@ -1,0 +1,6 @@
+task: create
+host: https://islandora.traefik.me
+username: admin
+password: password
+use_node_title_for_media: true
+field_for_media_title: true

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -1,19 +1,34 @@
-
 import unittest
-import WorkbenchConfig
+import argparse
+from WorkbenchConfig import WorkbenchConfig
 
-
-"""
-TODO
-
-* Need to figure out how to test things. May need to load up my own version of a config file that I then compare to the
-default config values???
-
-* need to instantiate an instance of the WorkbenchConfig to test it
-  
-"""
 
 class Test(unittest.TestCase):
-    # def test_get_config(selfself):
+
+    def test_path_check_valid_file(self):
+        test_file_name = '/file/does/not/exist.yml'
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--config', required=True, help='Configuration file to use.')
+        args = parser.parse_args(['--config', test_file_name])
+
+        with self.assertRaises(SystemExit) as exit_return:
+            WorkbenchConfig(args)
+
+        error_message = 'Error: Configuration file "' + test_file_name + '" not found.'
+        self.assertEqual(exit_return.exception.code, error_message)
+
+    # def test_path_check_fail(self):
+    #     test_file_name = 'tests/assets/execute_bootstrap_script_test/config.yml'
+    #     parser = argparse.ArgumentParser()
+    #     parser.add_argument('--config', required=True, help='Configuration file to use.')
+    #     args = parser.parse_args(['--config', test_file_name], '--check')
+    #
+    #     with self.assertRaises(SystemExit) as exit_return:
+    #         WorkbenchConfig(args)
+    #
+    #     error_message = 'Error: Configuration file "' + test_file_name + '" not found.'
+    #     self.assertEqual(exit_return.exception.code, error_message)
+
+    # def test_get_config(self):
     #     ...
 

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -1,0 +1,19 @@
+
+import unittest
+import WorkbenchConfig
+
+
+"""
+TODO
+
+* Need to figure out how to test things. May need to load up my own version of a config file that I then compare to the
+default config values???
+
+* need to instantiate an instance of the WorkbenchConfig to test it
+  
+"""
+
+class Test(unittest.TestCase):
+    # def test_get_config(selfself):
+    #     ...
+

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -56,7 +56,7 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         # TODO: check values sent to logger
 
-    def test_get_config_config_file_01(self):
+    def test_get_config_valid_config_file_01(self):
         test_file_name = 'tests/assets/WorkbenchConfig_test/config_01_create_short_valid.yml'
 
         args = self.parser.parse_args(['--config', test_file_name])
@@ -126,30 +126,27 @@ class TestWorkbenchConfig(unittest.TestCase):
             error_message = f'Error: Content type {content_type} does not exist on {host}.'
             self.assertEqual(exit_return.exception.code, error_message)
 
-#     def test_init_validate_invalid_mutators_01(self):
-#         test_file_name = 'tests/assets/WorkbenchConfig_test/config_02_02_create_short_invalid.yml'
-#
-#         args = self.parser.parse_args(['--config', test_file_name])
-#
-#         with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
-#                 patch('WorkbenchConfig.logging') as mocked_logging,\
-#                 self.assertRaises(SystemExit) as exit_return:
-#
-#             mocked_logging.return_value = None
-#
-#             fake_response = namedtuple('fake_response', ['status_code'])
-#             fake_response.status_code = 200
-#             mocked_issue_request.return_value = fake_response
-#
-#             test_config_obj = WorkbenchConfig(args)
-#
-#
-#             error_message = """Error: You may only select one of ['use_node_title_for_media',
-#             'use_nid_in_media_title', 'field_for_media_title'].
-#   - This config  has selected ['use_node_title_for_media', 'use_nid_in_media_title'].
-# """
-#             # error_message = f"You may only select one of {mutators}.\n  - This config  has selected {selected}."
-#             self.assertEqual(exit_return.exception.code, error_message)
+    def test_init_validate_invalid_mutators_01(self):
+        test_file_name = 'tests/assets/WorkbenchConfig_test/config_02_02_create_short_invalid.yml'
+
+        args = self.parser.parse_args(['--config', test_file_name])
+
+        with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
+                patch('WorkbenchConfig.logging') as mocked_logging:
+
+            mocked_logging.return_value = None
+
+            fake_response = namedtuple('fake_response', ['status_code'])
+            fake_response.status_code = 200
+            mocked_issue_request.return_value = fake_response
+
+            # Error text should only be this line, therefore use ^ and $ at the start and end of the message respectively
+            error_message = "^Error: You may only select one of \['use_node_title_for_media', "  \
+                + "'use_nid_in_media_title', 'field_for_media_title'\].\n  - This config  has selected " \
+                + "\['use_node_title_for_media', 'use_nid_in_media_title'\].\n$"
+
+            with self.assertRaisesRegex(SystemExit, error_message) as exit_return:
+                test_config_obj = WorkbenchConfig(args)
 
     def test_init_validate_invalid_mutators_02(self):
         test_file_name = 'tests/assets/WorkbenchConfig_test/config_02_03_create_short_invalid.yml'
@@ -165,14 +162,11 @@ class TestWorkbenchConfig(unittest.TestCase):
             fake_response.status_code = 200
             mocked_issue_request.return_value = fake_response
 
-            with self.assertRaises(SystemExit) as exit_return:
+            # Error text should only be this line, therefore use ^ and $ at the start and end of the message respectively
+            error_message = "^Error: You may only select one of \['use_node_title_for_media', "  \
+                + "'use_nid_in_media_title', 'field_for_media_title'\].\n  - This config  has selected " \
+                + "\['use_node_title_for_media', 'field_for_media_title'\].\n$"
+
+            with self.assertRaisesRegex(SystemExit, error_message) as exit_return:
                 test_config_obj = WorkbenchConfig(args)
 
-                print(exit_return)
-
-            error_message = """Error: You may only select one of ['use_node_title_for_media', 'use_nid_in_media_title', 'field_for_media_title'].
-  - This config  has selected ['use_node_title_for_media', 'field_for_media_title'].
-"""
-            error_message = f"You may only select one of.\n  - This config  has selected."
-            # print(exit_return.exception.code, error_message)
-            # self.assertEqual(exit_return.exception.code, error_message)

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -37,6 +37,34 @@ class Test(unittest.TestCase):
     #     error_message = 'Error: Configuration file "' + test_file_name + '" not found.'
     #     self.assertEqual(exit_return.exception.code, error_message)
 
-    # def test_get_config(self):
-    #     ...
+    def test_get_config(self):
+        test_file_name = 'tests/assets/execute_bootstrap_script_test/config.yml'
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--config', required=True, help='Configuration file to use.')
+        parser.add_argument('--check', help='Check input data and exit without creating/updating/etc.',
+                            action='store_true')
+        parser.add_argument('--get_csv_template',
+                            help='Generate a CSV template using the specified configuration file.', action='store_true')
+
+        args = parser.parse_args(['--config', test_file_name])
+
+        with patch('WorkbenchConfig.WorkbenchConfig.validate') as mocked_validate,\
+                patch('WorkbenchConfig.logging') as mocked_logging:
+
+            mocked_validate.return_value = None
+            mocked_logging.return_value = None
+
+            test_config_obj = WorkbenchConfig(args)
+
+            test_config_dict = test_config_obj.get_config()
+
+            # checking for config variables set in
+            # tests/assets/execute_bootstrap_script_test/config.yml
+            self.assertEqual(test_config_dict['task'], 'create')
+            self.assertEqual(test_config_dict['host'], 'https://islandora.traefik.me')
+            self.assertEqual(test_config_dict['username'], 'admin')
+            self.assertEqual(test_config_dict['password'], 'password')
+            self.assertEqual(test_config_dict['media_type'], 'document')
+
+        # TODO: check values sent to logger
 

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -1,7 +1,11 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch
 import argparse
 from collections import namedtuple
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from WorkbenchConfig import WorkbenchConfig
 
 
@@ -170,3 +174,6 @@ class TestWorkbenchConfig(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, error_message) as exit_return:
                 test_config_obj = WorkbenchConfig(args)
 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -1,17 +1,30 @@
 import unittest
 from unittest.mock import patch
 import argparse
-
+from collections import namedtuple
 from WorkbenchConfig import WorkbenchConfig
 
 
 class TestWorkbenchConfig(unittest.TestCase):
 
-    def test_path_check_valid_file(self):
-        test_file_name = '/file/does/not/exist.yml'
+    def setUp(self) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument('--config', required=True, help='Configuration file to use.')
-        args = parser.parse_args(['--config', test_file_name])
+        parser.add_argument('--check', help='Check input data and exit without creating/updating/etc.',
+                            action='store_true')
+        parser.add_argument('--get_csv_template',
+                            help='Generate a CSV template using the specified configuration file.', action='store_true')
+        parser.add_argument('--quick_delete_node',
+                            help='Delete the node (and all attached media) identified by the URL).')
+        parser.add_argument('--quick_delete_media', help='Delete the media (and attached file) identified by the URL).')
+        parser.add_argument('--contactsheet', help='Generate a contact sheet.', action='store_true')
+        parser.add_argument('--version', action='version', version='Islandora Workbench 0.0.0')
+        self.parser = parser
+
+    def test_init_path_check_invalid_file(self):
+        test_file_name = '/file/does/not/exist.yml'
+
+        args = self.parser.parse_args(['--config', test_file_name])
 
         with self.assertRaises(SystemExit) as exit_return,\
                 patch('WorkbenchConfig.logging') as mocked_logging:
@@ -25,28 +38,29 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         # TODO: check values sent to logger
 
-    # def test_path_check_fail(self):
-    #     test_file_name = 'tests/assets/execute_bootstrap_script_test/config.yml'
-    #     parser = argparse.ArgumentParser()
-    #     parser.add_argument('--config', required=True, help='Configuration file to use.')
-    #     args = parser.parse_args(['--config', test_file_name], '--check')
-    #
-    #     with self.assertRaises(SystemExit) as exit_return:
-    #         WorkbenchConfig(args)
-    #
-    #     error_message = 'Error: Configuration file "' + test_file_name + '" not found.'
-    #     self.assertEqual(exit_return.exception.code, error_message)
-
-    def test_get_config(self):
+    def test_init_path_check_valid_file(self):
         test_file_name = 'tests/assets/execute_bootstrap_script_test/config.yml'
-        parser = argparse.ArgumentParser()
-        parser.add_argument('--config', required=True, help='Configuration file to use.')
-        parser.add_argument('--check', help='Check input data and exit without creating/updating/etc.',
-                            action='store_true')
-        parser.add_argument('--get_csv_template',
-                            help='Generate a CSV template using the specified configuration file.', action='store_true')
 
-        args = parser.parse_args(['--config', test_file_name])
+        args = self.parser.parse_args(['--config', test_file_name])
+
+        with patch('sys.exit', side_effect=lambda x: None) as mock_exit, \
+                patch('WorkbenchConfig.WorkbenchConfig.validate') as mocked_validate, \
+                    patch('WorkbenchConfig.logging') as mocked_logging:
+
+            mocked_validate.return_value = None
+            mocked_logging.return_value = None
+
+            WorkbenchConfig(args)
+
+            mock_exit.assert_not_called()
+
+        # TODO: check values sent to logger
+
+
+    def test_get_config_config_file_01(self):
+        test_file_name = 'tests/assets/WorkbenchConfig_test/config_01_create_short_valid.yml'
+
+        args = self.parser.parse_args(['--config', test_file_name])
 
         with patch('WorkbenchConfig.WorkbenchConfig.validate') as mocked_validate,\
                 patch('WorkbenchConfig.logging') as mocked_logging:
@@ -64,7 +78,102 @@ class TestWorkbenchConfig(unittest.TestCase):
             self.assertEqual(test_config_dict['host'], 'https://islandora.traefik.me')
             self.assertEqual(test_config_dict['username'], 'admin')
             self.assertEqual(test_config_dict['password'], 'password')
-            self.assertEqual(test_config_dict['media_type'], 'document')
+            # self.assertEqual(test_config_dict['media_type'], 'document')
 
         # TODO: check values sent to logger
 
+    def test_init_validate_valid(self):
+        test_file_name = 'tests/assets/WorkbenchConfig_test/config_01_create_short_valid.yml'
+
+        args = self.parser.parse_args(['--config', test_file_name])
+
+        with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
+                patch('WorkbenchConfig.logging') as mocked_logging:
+
+            mocked_logging.return_value = None
+
+            fake_response = namedtuple('fake_response', ['status_code'])
+            fake_response.status_code = 200
+            mocked_issue_request.return_value = fake_response
+
+            test_config_obj = WorkbenchConfig(args)
+
+            content_type = 'islandora_object'
+            url = f"https://islandora.traefik.me/entity/entity_form_display/node.{content_type}.default?_format=json"
+            mocked_issue_request.assert_called_with(test_config_obj.get_config(), 'GET', url)
+
+    def test_init_validate_invalid_content_type(self):
+        test_file_name = 'tests/assets/WorkbenchConfig_test/config_02_01_create_short_invalid.yml'
+
+        args = self.parser.parse_args(['--config', test_file_name])
+
+        with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
+                patch('WorkbenchConfig.logging') as mocked_logging,\
+                self.assertRaises(SystemExit) as exit_return:
+
+            mocked_logging.return_value = None
+
+            fake_response = namedtuple('fake_response', ['status_code'])
+            fake_response.status_code = 404
+            mocked_issue_request.return_value = fake_response
+
+            test_config_obj = WorkbenchConfig(args)
+
+            content_type = 'invalid_content_type'
+            host = 'https://islandora.traefik.me'
+            url = f"{host}/entity/entity_form_display/node.{content_type}.default?_format=json"
+            mocked_issue_request.assert_called_with(test_config_obj.get_config(), 'GET', url)
+
+            error_message = f'Error: Content type {content_type} does not exist on {host}.'
+            self.assertEqual(exit_return.exception.code, error_message)
+
+#     def test_init_validate_invalid_mutators_01(self):
+#         test_file_name = 'tests/assets/WorkbenchConfig_test/config_02_02_create_short_invalid.yml'
+#
+#         args = self.parser.parse_args(['--config', test_file_name])
+#
+#         with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
+#                 patch('WorkbenchConfig.logging') as mocked_logging,\
+#                 self.assertRaises(SystemExit) as exit_return:
+#
+#             mocked_logging.return_value = None
+#
+#             fake_response = namedtuple('fake_response', ['status_code'])
+#             fake_response.status_code = 200
+#             mocked_issue_request.return_value = fake_response
+#
+#             test_config_obj = WorkbenchConfig(args)
+#
+#
+#             error_message = """Error: You may only select one of ['use_node_title_for_media', 'use_nid_in_media_title', 'field_for_media_title'].
+#   - This config  has selected ['use_node_title_for_media', 'use_nid_in_media_title'].
+# """
+#             # error_message = f"You may only select one of {mutators}.\n  - This config  has selected {selected}."
+#             self.assertEqual(exit_return.exception.code, error_message)
+
+    def test_init_validate_invalid_mutators_02(self):
+        test_file_name = 'tests/assets/WorkbenchConfig_test/config_02_03_create_short_invalid.yml'
+
+        args = self.parser.parse_args(['--config', test_file_name])
+
+        with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
+                patch('WorkbenchConfig.logging') as mocked_logging:
+
+
+            mocked_logging.return_value = None
+
+            fake_response = namedtuple('fake_response', ['status_code'])
+            fake_response.status_code = 200
+            mocked_issue_request.return_value = fake_response
+
+            with self.assertRaises(SystemExit) as exit_return:
+                test_config_obj = WorkbenchConfig(args)
+
+                print(exit_return)
+
+            error_message = """Error: You may only select one of ['use_node_title_for_media', 'use_nid_in_media_title', 'field_for_media_title'].
+  - This config  has selected ['use_node_title_for_media', 'field_for_media_title'].
+"""
+            error_message = f"You may only select one of.\n  - This config  has selected."
+            # print(exit_return.exception.code, error_message)
+            # self.assertEqual(exit_return.exception.code, error_message)

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -5,7 +5,7 @@ import argparse
 from WorkbenchConfig import WorkbenchConfig
 
 
-class Test(unittest.TestCase):
+class TestWorkbenchConfig(unittest.TestCase):
 
     def test_path_check_valid_file(self):
         test_file_name = '/file/does/not/exist.yml'

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -26,7 +26,7 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         args = self.parser.parse_args(['--config', test_file_name])
 
-        with self.assertRaises(SystemExit) as exit_return,\
+        with self.assertRaises(SystemExit) as exit_return, \
                 patch('WorkbenchConfig.logging') as mocked_logging:
 
             mocked_logging.return_value = None
@@ -45,7 +45,7 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         with patch('sys.exit', side_effect=lambda x: None) as mock_exit, \
                 patch('WorkbenchConfig.WorkbenchConfig.validate') as mocked_validate, \
-                    patch('WorkbenchConfig.logging') as mocked_logging:
+                patch('WorkbenchConfig.logging') as mocked_logging:
 
             mocked_validate.return_value = None
             mocked_logging.return_value = None
@@ -56,13 +56,12 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         # TODO: check values sent to logger
 
-
     def test_get_config_config_file_01(self):
         test_file_name = 'tests/assets/WorkbenchConfig_test/config_01_create_short_valid.yml'
 
         args = self.parser.parse_args(['--config', test_file_name])
 
-        with patch('WorkbenchConfig.WorkbenchConfig.validate') as mocked_validate,\
+        with patch('WorkbenchConfig.WorkbenchConfig.validate') as mocked_validate, \
                 patch('WorkbenchConfig.logging') as mocked_logging:
 
             mocked_validate.return_value = None
@@ -108,7 +107,7 @@ class TestWorkbenchConfig(unittest.TestCase):
         args = self.parser.parse_args(['--config', test_file_name])
 
         with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
-                patch('WorkbenchConfig.logging') as mocked_logging,\
+                patch('WorkbenchConfig.logging') as mocked_logging, \
                 self.assertRaises(SystemExit) as exit_return:
 
             mocked_logging.return_value = None
@@ -145,7 +144,8 @@ class TestWorkbenchConfig(unittest.TestCase):
 #             test_config_obj = WorkbenchConfig(args)
 #
 #
-#             error_message = """Error: You may only select one of ['use_node_title_for_media', 'use_nid_in_media_title', 'field_for_media_title'].
+#             error_message = """Error: You may only select one of ['use_node_title_for_media',
+#             'use_nid_in_media_title', 'field_for_media_title'].
 #   - This config  has selected ['use_node_title_for_media', 'use_nid_in_media_title'].
 # """
 #             # error_message = f"You may only select one of {mutators}.\n  - This config  has selected {selected}."
@@ -158,7 +158,6 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         with patch('WorkbenchConfig.issue_request') as mocked_issue_request, \
                 patch('WorkbenchConfig.logging') as mocked_logging:
-
 
             mocked_logging.return_value = None
 

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -1,5 +1,7 @@
 import unittest
+from unittest.mock import patch
 import argparse
+
 from WorkbenchConfig import WorkbenchConfig
 
 
@@ -11,11 +13,17 @@ class Test(unittest.TestCase):
         parser.add_argument('--config', required=True, help='Configuration file to use.')
         args = parser.parse_args(['--config', test_file_name])
 
-        with self.assertRaises(SystemExit) as exit_return:
+        with self.assertRaises(SystemExit) as exit_return,\
+                patch('WorkbenchConfig.logging') as mocked_logging:
+
+            mocked_logging.return_value = None
+
             WorkbenchConfig(args)
 
         error_message = 'Error: Configuration file "' + test_file_name + '" not found.'
         self.assertEqual(exit_return.exception.code, error_message)
+
+        # TODO: check values sent to logger
 
     # def test_path_check_fail(self):
     #     test_file_name = 'tests/assets/execute_bootstrap_script_test/config.yml'


### PR DESCRIPTION
## Link to Github issue or other discussion

#445 

## What does this PR do?

Adds a few unit tests using the Python built-in`unittest` module to WorkbenchConfig.py

## What changes were made?

New unit test file added called `tests/unit_tests_workbench_config.py` but it may make sense to integrate the unit tests into a pre-existing existing unitest file. 

Also added some test config.yml files in:
tests/assets/WorkbenchConfig_test

There might be a better approach to test WorkbenchConfig.py that having several different config files, but this seems like a good starting point. We may want to come up with a standardized way to name the test config files.


## How to test / verify this PR?

Write now my unittest code works with this execution syntax:
 
python3 -m unittest -v tests/unit_tests_workbench_config.py

NOTE:  I will make changes so that in the future my test(s) works with the syntax used for other isladnora_workbench tests. I am using this as an experiment to learn Python and unittest module best practices.

## Interested Parties

@mjordan

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
