### PR TITLE
Fixes skipped URL alias additions when "file" field is unspecified

### DIFF
--- a/workbench
+++ b/workbench
@@ -314,6 +314,12 @@ def create():
             row_position = get_percentage(row_count, num_csv_records)
             pbar(row_position)
 
+        # If 'url_alias' is in the CSV, create the alias.
+        if 'url_alias' in row and len(row['url_alias']) > 0:
+            create_url_alias(config, node_id, row['url_alias'])
+
+        write_rollback_config(config, path_to_rollback_csv_file)
+
         # If there is no media file (and we're not creating paged content), move on to the next CSV row.
         if config['nodes_only'] is False and 'file' in row and len(row['file'].strip()) == 0 and config['paged_content_from_directories'] is False:
             if config['progress_bar'] is False:
@@ -371,12 +377,6 @@ def create():
             if config['paged_content_from_directories'] is True:
                 # Console output and logging are done in the create_children_from_directory() function.
                 create_children_from_directory(config, row_as_parent, node_id)
-
-            # If 'url_alias' is in the CSV, create the alias.
-            if 'url_alias' in row and len(row['url_alias']) > 0:
-                create_url_alias(config, node_id, row['url_alias'])
-
-            write_rollback_config(config, path_to_rollback_csv_file)
 
 
 def update():

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -4545,7 +4545,7 @@ def create_url_alias(config, node_id, url_alias):
             url_alias,
             config['host'] +
             '/node/' +
-            node_id,
+            str(node_id),
             response.status_code)
 
 


### PR DESCRIPTION

## Link to Github issue or other discussion

* address https://github.com/mjordan/islandora_workbench/issues/703

## What does this PR do?

* Addresses a code path during the create workflow that will skip the creation of the URL alias in Drupal
* Addresses 'TypeError: can only concatenate str (not "int") to str' if preexisting URL alias exists on the Drupal site
* Also, rollback config .yml creation was being skipped

## What changes were made?

* Moves the code block that creates the URL Alias to a location above the a code block containing a `continue`  statement thus skipping the URL Alias creation. The code block: https://github.com/mjordan/islandora_workbench/blob/f41fa85b0afac02c9a6adc9d92c1a8355624f8cd/workbench#L318-L322


## How to test / verify this PR?

* create an input CSV with the required fields, a specified `url_alias`, plus and empty `file` field (for example, a collection node)
* Workbench config: required items plus `allow_missing_files: true`

## Interested Parties

@mjordan 

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you run `pycodestyle --show-source --show-pep8 --ignore=E402,W504 --max-line-length=200 yourfile.py`? 
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
