### PR TITLE
Dockerfile: `python3 setup.py install` is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ WORKDIR /workbench
 RUN python -m pip install setuptools
 
 # RUN pip install filemagic
-RUN pip install urllib3>=1.21.1
-RUN pip install libmagic
-RUN python setup.py install
+RUN pip install libmagic urllib3>=1.21.1
+RUN pip install --editable .


### PR DESCRIPTION
https://packaging.python.org/en/latest/discussions/setup-py-deprecated

Let's try `pip install --editable .` instead.

Also, `pip` now has a real dependency resolver to provide it all dependencies in a single command.

Why not put `libmagic` and `urllib3` in `setup.py`'s `install_requires` list?