### PR TITLE
Accommodate Typed Relation Display name Fields

### DIFF
--- a/workbench
+++ b/workbench
@@ -318,6 +318,13 @@ def create():
                     config, field_definitions, node, row, custom_field
                 )
 
+            # Typed relation with display name fields.
+            elif field_definitions[custom_field]["field_type"] == "typed_relation_display_name":
+                typed_relation_display_name_field = workbench_fields.TypedRelationDisplayNameField()
+                node = typed_relation_display_name_field.create(
+                    config, field_definitions, node, row, custom_field
+                )
+
             # Geolocation fields.
             elif field_definitions[custom_field]["field_type"] == "geolocation":
                 geolocation_field = workbench_fields.GeolocationField()
@@ -792,6 +799,18 @@ def update():
             elif field_definitions[custom_field]["field_type"] == "typed_relation":
                 typed_relation_field = workbench_fields.TypedRelationField()
                 node = typed_relation_field.update(
+                    config,
+                    field_definitions,
+                    node,
+                    row,
+                    custom_field,
+                    node_field_values[custom_field],
+                )
+
+            # Typed relation display name fields (currently, only taxonomy term).
+            elif field_definitions[custom_field]["field_type"] == "typed_relation_display_name":
+                typed_relation_display_name_field = workbench_fields.TypedRelationDisplayNameField()
+                node = typed_relation_display_name_field.update(
                     config,
                     field_definitions,
                     node,
@@ -1970,6 +1989,18 @@ def update_media() -> None:
                 elif field_definitions[custom_field]["field_type"] == "typed_relation":
                     typed_relation_field = workbench_fields.TypedRelationField()
                     patch_request_json = typed_relation_field.update(
+                        config,
+                        field_definitions,
+                        patch_request_json,
+                        row,
+                        custom_field,
+                        media_field_values[custom_field],
+                    )
+
+                # Typed relation display name fields (currently, only taxonomy term).
+                elif field_definitions[custom_field]["field_type"] == "typed_relation_display_name":
+                    typed_relation_display_name_field = workbench_fields.TypedRelationDisplayNameField()
+                    patch_request_json = typed_relation_display_name_field.update(
                         config,
                         field_definitions,
                         patch_request_json,
@@ -3231,6 +3262,18 @@ def update_terms():
             elif field_definitions[custom_field]["field_type"] == "typed_relation":
                 typed_relation_field = workbench_fields.TypedRelationField()
                 term = typed_relation_field.update(
+                    config,
+                    field_definitions,
+                    term,
+                    row,
+                    custom_field,
+                    term_field_values[custom_field],
+                )
+
+            # Typed relation display name fields (currently, only taxonomy term).
+            elif field_definitions[custom_field]["field_type"] == "typed_relation_display_name":
+                typed_relation_display_name_field = workbench_fields.TypedRelationDisplaynameField()
+                term = typed_relation_display_name_field.update(
                     config,
                     field_definitions,
                     term,


### PR DESCRIPTION
## Link to Github issue or other discussion

For my new module, [Typed Relation with Display name](https://github.com/rosiel/typed_relation_display_name/), we need to alter Workbench to allow it to do what's needed to populate and export these new fields.
 
## What does this PR do?

Adds support for Typed Relation field

## What changes were made?

Duplicate existing class for TypedRelationField
Duplicate existing function for splitting the field value
Duplicate all invocations that test whether the field is a typed relation field.

Just to note that Workbench fails silently (no logs, no errors, just doesn't write to the field) if the field type is not recognized. While there is [documentation](https://mjordan.github.io/islandora_workbench_docs/development_guide/#overview-of-how-workbench-handles-field-types) for what fields are supported (will need to be updated?) I'm not sure if failing silently is the best option here? Open to discussion, just wanted to mention this.

## How to test / verify this PR?

* Install Typed Relation Display Name module
* add a Typed Relation Display Name field to Repository Item
* create a CSV with values such as: (first three equivalent to Typed Relation, since display name is optional)
  * "relators:aut:119"
  * "relators:aut:Rosie Le Faive"
  * "relators:aut:person:Rosie Le Faive"
  * "relators:aut:119~Le Faive, R.A."
  * "relators:aut:Rosie Le Faive~Le Faive, R.A."
  * "relators:aut:person:Rosie Le Faive~Le Faive, R.A."

## Interested Parties

 @mjordan_

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
