### PR TITLE
Always set index

### DIFF
--- a/i7Import/get_islandora_7_content.py
+++ b/i7Import/get_islandora_7_content.py
@@ -78,7 +78,7 @@ headers.append("sequence")
 headers.append("file")
 if config["id_field"] not in headers:
     headers.append(config["id_field"])
-    index = config["id_start_number"]
+index = config["id_start_number"]
 
 if config["fetch_files"] is True:
     if not os.path.exists(config["obj_directory"]):


### PR DESCRIPTION
The index should always be set, because it will be accessed later in the script and generate a runtime error

## What does this PR do?

Sets the index variable to the config's id_start_number, even if id_field was already in the header

## Why is this desirable ?

When each row is iterated later on in the script, index will be accessed. If it is not set, a runtime error occurs. 

```
        if config["id_field"] in headers:
            row[config["id_field"]] = index + reader.line_num - 2

```

