### PR TITLE
added override to assign media types by media use

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -286,6 +286,7 @@ class WorkbenchConfig:
             "csv_value_templates_rand_length": 5,
             "allow_csv_value_templates_if_field_empty": [],
             "remind_user_to_run_check": False,
+            "media_type_by_media_use": False,
         }
 
     # Tests validity and existence of configuration file path.

--- a/i7Import/i7ImportUtilities.py
+++ b/i7Import/i7ImportUtilities.py
@@ -56,6 +56,7 @@ class i7ImportUtilities:
         "start": 0,
         "rows": 100000,
         "secure_ssl_only": True,
+        "pids": False,
     }
 
     def get_config(self):
@@ -180,6 +181,12 @@ class i7ImportUtilities:
             for collection in collections:
                 fedora_collections.append(f'{fedora_prefix}"{collection}"')
             fq_string = "&fq=" + " or ".join(fedora_collections)
+            query = f"{query}{fq_string}"
+        if self.config["pids"]:
+            pids_to_use = []
+            for candidate in self.config["pids"]:
+                pids_to_use.append(f"PID:{candidate}")
+            fq_string = "&fq=" + " or ".join(pids_to_use)
             query = f"{query}{fq_string}"
 
         # Get the populated CSV from Solr, with the object namespace and field list filters applied.

--- a/tests/assets/set_media_type_test/multi_types_config.yml
+++ b/tests/assets/set_media_type_test/multi_types_config.yml
@@ -16,3 +16,6 @@ media_types_override:
  - sometextmedia: ['txt']
 
 secure_ssl_only: false
+
+media_type_by_media_use:
+  - https://projects.iq.harvard.edu/fits: fits_technical_metadata

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -79,6 +79,14 @@ def set_media_type(config, filepath, file_fieldname, csv_row):
     """
     if "media_type" in config:
         return config["media_type"]
+    if config["media_type_by_media_use"] and len(config["media_type_by_media_use"]) > 0:
+        additional_files = get_additional_files_config(config)
+        media_url = additional_files.get(file_fieldname)
+        if file_fieldname in additional_files:
+            for entry in config["media_type_by_media_use"]:
+                for key, value in entry.items():
+                    if key == media_url:
+                        return value
 
     # Determine if the incomtimg filepath matches a registered eEmbed media type.
     oembed_media_type = get_oembed_url_media_type(config, filepath)


### PR DESCRIPTION
## Link to Github issue or other discussion

> **[Addresses issue 836](https://github.com/mjordan/islandora_workbench/issues/836)**
## What does this PR do?

> **Allows definition of media types** 

## What changes were made?

> **Added and implemented  media_type_by_media_use config** 
(also threw in a parameter to allow harvesting i7 data from a list of PIDS)

## How to test / verify this PR?

> **add this to config if additional fields have been defined.  Test files should now be of correct media type** 
```
media_type_by_media_use:
  - https://projects.iq.harvard.edu/fits: fits_technical_metadata
```
```
additional_files:
 - extracted: http://pcdm.org/use#ExtractedText
 - fits: https://projects.iq.harvard.edu/fits
 - service: http://pcdm.org/use#ServiceFile
 - thumbnail: http://pcdm.org/use#ThumbnailImage
```

  -
## Interested Parties

> ** @mjordan** 

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
