### PR TITLE
Add pids_to_skip to i7ImportUtilities

### DIFF
--- a/i7Import/i7ImportUtilities.py
+++ b/i7Import/i7ImportUtilities.py
@@ -57,6 +57,7 @@ class i7ImportUtilities:
         "rows": 100000,
         "secure_ssl_only": True,
         "pids": False,
+        "pids_to_skip": [],
     }
 
     def get_config(self):


### PR DESCRIPTION
## Link to Github issue or other discussion

#911 

## What does this PR do?

If not in the user provided configuration you get a `KeyError`

## What changes were made?

Added to the default configuration

## How to test / verify this PR?

Make a simple PR, using the example in i7Import/configs/islandora7_import_sample.config
Try to run an i7 export, see
```bash
> python3 i7Import/get_islandora_7_content.py --config islandora7_export.config.yml 
Processing 100.
Traceback (most recent call last):
  File "/Users/jaredwhiklo/www/DAM2/islandora_workbench/i7Import/get_islandora_7_content.py", line 96, in <module>
    if row["PID"] in config["pids_to_skip"]:
KeyError: 'pids_to_skip'
```

With this PR and no changes to your config. See it not fail.


## Interested Parties

@mjordan

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
