### PR TITLE
Fix password string replacement

### DIFF
--- a/scripts/make_local_tests.py
+++ b/scripts/make_local_tests.py
@@ -1,13 +1,13 @@
 """Utility script to replace host, username, and password values in
-   Islandora Workbench test config files.
+Islandora Workbench test config files.
 
-   Usage (run from within the workbench directory):
+Usage (run from within the workbench directory):
 
-   python scripts/make_local_tests.py
+python scripts/make_local_tests.py
 
-   or, with any of the optional arguments:
+or, with any of the optional arguments:
 
-   python scripts/make_local_tests.py --host http://localhost:8080 --username mark --password islandora
+python scripts/make_local_tests.py --host http://localhost:8080 --username mark --password islandora
 """
 
 import os
@@ -15,6 +15,7 @@ import sys
 import shutil
 import glob
 import argparse
+import re
 
 current_dir = os.getcwd()
 path_to_workbench = os.path.join(current_dir, "workbench")
@@ -55,7 +56,7 @@ for filepath in list(glob.iglob(f"{local_tests_dir}/**/*.yml", recursive=True)) 
     config = f.read()
     config = config.replace("https://islandora.dev", args.host)
     config = config.replace("admin", args.username)
-    config = config.replace("password", args.password)
+    config = re.sub("password$", args.password, config, 0, re.MULTILINE)
     config = config.replace("tests/assets/", "tests_local/assets/")
     f = open(filepath, "w")
     f.write(config)


### PR DESCRIPTION
## Link to Github issue or other discussion

Resolved #918 

## What does this PR do?

Replaces the password only from the end of the string, instead of the start.

## What changes were made?



## How to test / verify this PR?

Run a command like
```bash
python3 scripts/make_local_tests.py --host https://jared.uri --username test_username --password somePassword
```
Then check one of the configuration files changed and in the `tests_local` directory, (i.e. `tests_local/assets/check_test/delete.yml`)
```yaml
task: delete
host: https://jared.uri
username: test_username
somePassword: somePassword
input_csv: delete.csv
secure_ssl_only: false
```
Pull in this PR, re-run `make_local_tests.py` command and check the file again
```yaml
task: delete
host: https://jared.uri
username: test_username
password: somePassword
input_csv: delete.csv
secure_ssl_only: false
```



## Interested Parties

@mjordan

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
