### PR TITLE
adding a Makefile to make running in docker easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+USER_ID=`id -u`
+GROUP_ID=`id -g`
+GIT_COMMIT=`git rev-parse HEAD`
+
+.PHONY: build-islandora-workbench
+# This command will build a new image for the current git revision, if none exists
+build-islandora-workbench:
+	(docker image ls | grep $(GIT_COMMIT)) || $(MAKE) rebuild-islandora-workbench
+
+.PHONY: rebuild-islandora-workbench
+# This command will force build a new image for the current git revision, regardless of whether one exists
+rebuild-islandora-workbench:
+	docker build --build-arg USER_ID=$(USER_ID) --build-arg GROUP_ID=$(GROUP_ID) -t "workbench-docker-$(GIT_COMMIT)" . 
+
+.PHONY: run-workbench-in-docker
+# This command will bring up the container and drop you into a shell.
+# The current working directory will be mounted at /workbench inside the container.
+run-workbench-in-docker: build-islandora-workbench
+	docker run -it --rm --network="host" -v $$(pwd):/workbench -v --name "workbench-docker-$(GIT_COMMIT)" bash 


### PR DESCRIPTION
This MR adds a Makefile which gives a single command which allows islandora_workbench to be spun up in Docker instead of run locally. This gets around local Python issues, etc.

To test, you must have Docker installed and then you can run `run-workbench-in-docker`. 

You can also run `make build-islandora-workbench` to build the image, but that's a dependency of the above, so it should happen automatically. If you change git commit on your local, it will automatically know to do a rebuild. If for whatever reason you have to force a rebuild, run `make rebuild-islandora-workbench`.