### PR TITLE
Fix for #946: export_csv task drops some field_member_of values

### DIFF
--- a/workbench_fields.py
+++ b/workbench_fields.py
@@ -1018,10 +1018,17 @@ class EntityReferenceField:
                 term_name = get_term_name(config, subvalue["target_id"])
                 if vocab_id is not False and term_name is not False:
                     subvalues.append(vocab_id + ":" + term_name)
-            else:
+            elif subvalue["target_type"] == "taxonomy_term":
                 # Output term IDs.
                 if ping_term(config, subvalue["target_id"]) is True:
                     subvalues.append(str(subvalue["target_id"]))
+            elif subvalue["target_type"] == "node":
+                # Output node IDs.
+                if ping_node(config, subvalue["target_id"]) is True:
+                    subvalues.append(str(subvalue["target_id"]))
+            else:
+                # Fallback for any other entity type.
+                subvalues.append(str(subvalue["target_id"]))
 
         if len(subvalues) > 1:
             return config["subdelimiter"].join(subvalues)


### PR DESCRIPTION


Check the entity type of a referenced object before trying to ping it.

## Link to Github issue or other discussion


#946 
## What does this PR do?


This change means that when the workbench_fields.py::serialize() function is called, it will no longer try to ping a node's Id as if it were a taxonomy term. This would succeed much of the time due to overlap of the Nid with an unrelated Tid.

## What changes were made?

In workbench_fields.py::serialize, added extra checks for if the entity being referenced is a term or a node and calls the appropriate ping_* function depending on which one it is.

Also adds a fallback for any other type of entity where the id is included without trying to ping any URL.  

## How to test / verify this PR?

From a fresh Islandora Starter Site, load the Islandora Demo Objects.
```shell
python3 ../islandora_workbench/workbench --config create_islandora_objects.yml

```

Then check out the main branch and run an export with the rollback CSV that was created by the load task.

Here's a task config for that:

```yaml
task: export_csv
host: "https://islandora.dev"
username: admin
password: password
input_dir: .
input_csv: rollback.csv
export_csv_term_mode: name
content_type: islandora_object
export_csv_file_path: export_csv_output.csv
export_file_url_instead_of_download: False
export_file_directory: exported_files
secure_ssl_only: False
enable_http_cache: True
```

Since we need to check the case where a Nid does not have a Tid with the same number, so look in the CSV for one of the Cadre issues, probably something like '77'.

Go to https://islandora.dev/taxonomy/term/77 , you'll likely find a taxonomy term there due to some new vocabularies that have been added to the starter site:

![image](https://github.com/user-attachments/assets/5ee727bf-f922-422c-a0d8-6b134ff62cdc)


Temporarily delete this term so that the URL does not resolve.

Then run the output task with 'main' branch checked out of islandora_workbench:

Output on main branch:


![image](https://github.com/user-attachments/assets/7ac9b24d-c82a-4329-83fc-23584da5c643)



[export_csv_output-main.csv](https://github.com/user-attachments/files/20015784/export_csv_output-main.csv)

Then checkout the PR branch and re-run the export task.

Output after checking out this PR branch:Then check out the PR branch and re-run the export task.


[export_csv_output-946-export-node-ids.csv](https://github.com/user-attachments/files/20015783/export_csv_output-946-export-node-ids.csv)
![image](https://github.com/user-attachments/assets/241c04d3-dfbb-4337-90ba-573625713904)

## Interested Parties

@mjordan @rosiel 

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [Y] Have you included some configuration and/or CSV files useful for testing this PR?
* [N/A] Have you written unit or integration tests if applicable?
* [N] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [N/A] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [N/A] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
