### PR TITLE
Print out additional YAML exception error info from get_user_config()

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -118,6 +118,11 @@ class WorkbenchConfig:
                 print(
                     f"There appears to be a YAML syntax error in your configuration file, {self.args.config}. Remove the username and\npassword, and run the file through https://codebeautify.org/yaml-validator/ or your YAML validator of choice."
                 )
+                # No using logging.error() here because this method will run inside
+                # WorkbenchConfig.__init__() before the logger is configured
+                yaml_error = f"\nException type: {type(exc).__name__}\n{exc}"
+                print(yaml_error)
+
                 sys.exit()
 
         # 'media_file_fields' has been replaced with 'media_fields' and 'media_type_file_fields'.

--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -116,12 +116,21 @@ class WorkbenchConfig:
                 loaded = yaml.load(stream)
             except YAMLError as exc:
                 print(
-                    f"There appears to be a YAML syntax error in your configuration file, {self.args.config}. Remove the username and\npassword, and run the file through https://codebeautify.org/yaml-validator/ or your YAML validator of choice."
+                    f"There appears to be a YAML syntax error in your configuration file, {self.args.config}. Remove "
+                    f"the username and\npassword, and run the file through https://codebeautify.org/yaml-validator/ "
+                    f"or your YAML validator of choice.\n"
+                    f"(Check 'workbench.log' file for additional error details.)"
                 )
-                # No using logging.error() here because this method will run inside
-                # WorkbenchConfig.__init__() before the logger is configured
-                yaml_error = f"\nException type: {type(exc).__name__}\n{exc}"
-                print(yaml_error)
+                # We are using logging.basicConfig() here to set a temporary logger here because this method will
+                # run inside WorkbenchConfig.__init__() before the WorkbenchConfig class logger is configured.
+                # Also by using the logger we don't have to output the YAML parsing errors to the CLI
+                logging.basicConfig(
+                    filename="workbench.log",
+                    format="%(asctime)s - %(levelname)s - %(message)s",
+                    datefmt="%d-%b-%y %H:%M:%S",
+                )
+                yaml_error = f"\nYAML parsing error in configuration file\nException type: {type(exc).__name__}\n{exc}"
+                logging.error(yaml_error)
 
                 sys.exit()
 


### PR DESCRIPTION
## Link to Github issue or other discussion

https://github.com/mjordan/islandora_workbench/issues/969

## What does this PR do?

Print more details about YAML errors in the passed config.yml file.

## What changes were made?

I am grabbing details from the raised YAMLError exception and printing them to the CLI.

## How to test / verify this PR?

I am attaching an example config.yml file that is an RTF/plaintext hybrid, but it has been renamed to config.txt to allow me to upload it to the issue.

[config_rtf_plaintext_hybrid.txt](https://github.com/user-attachments/files/20746513/config_rtf_plaintext_hybrid.txt)


## Interested Parties

@mjordan

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
