### PR TITLE
Reduce log message level for missing additional file fields

### DIFF
--- a/workbench
+++ b/workbench
@@ -596,7 +596,10 @@ def create():
                                 print(
                                     "- " + message + ". See log for more information."
                                 )
-                            logging.error(message + " because CSV field is empty.")
+                            if config["allow_missing_files"] is False:
+                                logging.error(message + " because CSV field is empty.")
+                            else:
+                                logging.warning(message + " because CSV field is empty.")
                             continue
                         filename = row[additional_file_field].strip()
                         file_exists = check_file_exists(config, filename)


### PR DESCRIPTION
Reduces log level from error to warn for empty additional file fields when `allow_missing_files` flag is true 

The log was getting full of errors when the situation is more expected when working with mixed content (aka some rows have thumbnails and others don't)

## Link to Github issue or other discussion

N/A

## What does this PR do?

Reduces the log level to warning for missing additional file fields values when  `allow_missing_files` flag is true 

## What changes were made?

Log level for a specific situation

## How to test / verify this PR?

have an additional_files + column in csv with some values present and some not

ex:

> config.yaml
```yaml
task: create
host: '<CHANGE THIS TO THE URL FOR YOUR ISLANDORA INSTALLATION. EX: `https://islandora.traefik.me`>'
username: '<CHANGE THIS TO YOUR USERNAME. EX: `admin`>'
secure_ssl_only: false
id_field: field_identifier
input_dir: alcuinbookawards_workbench_input_files
allow_missing_files: true
allow_adding_terms: true
content_type: sfu_repository_item
csv_field_templates:
- field_publisher: The Alcuin Society
- field_language: English
- field_sfu_copyright: https://lib.sfu.ca/term/copyrightprotected
- field_sfu_terms_of_use: https://lib.sfu.ca/term/fairdealingcontactowner
field_viewer_override_models:
- http://mozilla.github.io/pdf.js: ["https://schema.org/DigitalDocument"]
additional_files:
- thumbnail: http://pcdm.org/use#ThumbnailImage
```

> alcuinbookawards_workbench_input_files/metadata.csv
```csv
field_identifier,field_member_of,parent_id,field_model,field_sfu_issue,field_edtf_date,field_sfu_physical_description,field_weight,title,field_linked_agent,field_sfu_keywords,field_sfu_description,file,thumbnail
alcuinbookawards_publication,,,https://schema.org/Periodical,,,,,The Alcuin Society Awards for Excellence in Book Design in Canada,,,,,
alcuinbookawards_issue_vol_1_1984,,alcuinbookawards_publication,https://lib.sfu.ca/term/PublicationIssueWithArticles,,1984,,1,The Alcuin Society Awards for Excellence in Book Design in Canada : Vol. 1 (1984),,,,,https://journals.lib.sfu.ca/public/journals/39/1984-001.png
```


You should get a warning (instead of error) in the logs when running the above for the `alcuinbookawards_publication` record's thumbnail

## Interested Parties

@mjordan 

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
