### PR TITLE
Enhance task export_csv: address Drupal config where media file url is not included in JSON serialization of media

### DIFF
--- a/workbench_export.py
+++ b/workbench_export.py
@@ -25,6 +25,7 @@ class WorkbenchExportBase:
         ]
         self.seen_nids = set()
         self.pbar = InitBar() if config.get("progress_bar") else None
+        self.validate_export_config(config)
 
     @staticmethod
     def deduplicate_list(input_list):
@@ -166,6 +167,30 @@ class WorkbenchExportBase:
             message = "Skipping node with missing/invalid NID"
             self.log_progress(message, level=logging.WARNING)
             return None
+
+    def validate_export_config(self, config):
+        """Validate export related config"""
+        if config.get("export_file_directory") is None:
+            message = (
+                f'Configuration property "export_file_directory" is not configured.'
+            )
+            logging.error(message)
+            sys.exit("Error: " + message + " See log for more detail.")
+
+        if not os.path.exists(config["export_file_directory"]):
+            try:
+                os.mkdir(config["export_file_directory"])
+                logging.info(
+                    f'Path "export_file_directory" ("{config["export_file_directory"]}") created.'
+                )
+            except Exception as e:
+                message = f'Path "export_file_directory" ("{config["export_file_directory"]}") is not writable: {str(e)}'
+                logging.error(message)
+                sys.exit("Error: " + message + " See log for more detail.")
+        else:
+            logging.info(
+                f'Path "export_file_directory" ("{config["export_file_directory"]}") already exists.'
+            )
 
     def validate_content_type(self, node, nid):
         """Verify node matches configured content type."""

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -11076,6 +11076,29 @@ def resolve_media_use_term_id(
     return media_use_term_id
 
 
+def find_file_url_in_file(config: dict, file_info: list) -> Union[None, str]:
+    """Given a media target_id, lookup the File object and return the URL.
+    Parameters
+    :param config: dict - The configuration settings defined by WorkbenchConfig.get_config().
+    :param file_info: list - The file info list from the media entity.
+    :return: str|None - The file URL, or None on failure.
+    """
+    target_id = file_info[0].get("target_id")
+    file_metadata_url = f"{config['host']}/entity/file/{str(target_id)}?_format=json"
+    response = issue_request(config, "GET", file_metadata_url)
+    if response.status_code != 200:
+        logging.error(
+            f"File metadata entity request failed for file {target_id}: {response.status_code}"
+        )
+        return None
+    try:
+        file_metadata = json.loads(response.text)
+        return f"{config['host']}{file_metadata['uri'][0].get('url')}"
+    except json.decoder.JSONDecodeError as e:
+        logging.error(f"File metadata request for file {target_id} failed: {e}")
+        return None
+
+
 def find_file_url_in_media(
     config: dict, media_list: list, media_use_term_id: str, node_id: str
 ) -> Union[None, str]:
@@ -11098,6 +11121,8 @@ def find_file_url_in_media(
                         file_url = file_info[0].get("url")
                         if file_url:
                             return file_url
+                        else:
+                            return find_file_url_in_file(config, file_info)
     logging.warning(
         f"No valid media found for node {node_id} with use term {media_use_term_id}"
     )


### PR DESCRIPTION
## Link to Github issue or other discussion

#1025 

## What does this PR do?

Enhances the export_csv task by:

1. Add alternate method to find media file url via the `entity/file`; address mjordan#1025. Some Islandora sites don't respond with a media file url  property in the field_media_document, field_media_video_file, field_media_audio_file, field_media_file, etc., sections of the JSON response during a request to `node/{id}/media?_format=json`. Not reproducible on the Islandora Starter site.

2. Reduces noise in the workbench log by only testing if the export directory exists during initialization instead of each time a media is downloaded thus reducing workbench.log messages indicating "Path "export_file_directory" ("export_files") already exists."

## What changes were made?

Enhances the export_csv task by:

1. If the url property is not found via `node/{id}/media?_format=json` API then checks the `entity/file` API.
2. Reduces noise in the workbench log: creates an export validation method that runs during initialization replacing validation that run during each media download. 

## How to test / verify this PR?

1. media file url
a. should work against the islandora.sandbox.ca where media file url is part of the `node/{id}/media?_format=json` API
b. should download files on the Drupal site configured such that the media file url is only exposed by the `entity/file` API

3. export_csv task: workbench log output should only have one message for the following cases (not one for each media file downloaded)
a. test config without `export_file_directory`
b. test config with `export_file_directory` pointing to new directory
c. test config with `export_file_directory` pointing to an existing directory

Sample config

```
task: export_csv
host: "https://cwrc.ca"
username: admin
 
content_type: islandora_object
 
input_dir: /tmp/test1/
input_csv: input.csv
 
export_csv_term_mode: name
 

export_csv_file_path: /tmp/test1/islandora_object.output.csv
 
export_file_directory: /tmp/test1/islandora_object
```

