### PR TITLE
Fixes #1036: create_terms task crashes on cardinality validation during --check

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -7704,6 +7704,7 @@ def validate_csv_field_cardinality(config, field_definitions, csv_data):
                     field_cardinalities[field_name] == 1
                     and len(delimited_field_values) > 1
                 ):
+                    message = ""
                     if config["task"] == "create":
                         message = (
                             'CSV field "'
@@ -7712,7 +7713,7 @@ def validate_csv_field_cardinality(config, field_definitions, csv_data):
                             + row[config["id_field"]]
                             + " contains more values than the number "
                         )
-                    if config["task"] == "update":
+                    elif config["task"] == "update":
                         message = (
                             'CSV field "'
                             + field_name
@@ -7720,6 +7721,22 @@ def validate_csv_field_cardinality(config, field_definitions, csv_data):
                             + row["node_id"]
                             + " contains more values than the number "
                         )
+                    elif config["task"] == "create_terms":
+                        message = (
+                            'CSV field "'
+                            + field_name
+                            + '" in record with term name '
+                            + row["term_name"]
+                            + " contains more values than the number "
+                        )
+                    elif config["task"] == "update_terms":
+                        message = (
+                            'CSV field "'
+                            + field_name
+                            + '" in record with term ID '
+                            + row["term_id"]
+                            + " contains more values than the number "
+                        )                        
                     message_2 = (
                         "allowed for that field ("
                         + str(field_cardinalities[field_name])
@@ -7731,6 +7748,7 @@ def validate_csv_field_cardinality(config, field_definitions, csv_data):
                     int(field_cardinalities[field_name]) > 1
                     and len(delimited_field_values) > field_cardinalities[field_name]
                 ):
+                    message = ""
                     if config["task"] == "create":
                         message = (
                             'CSV field "'
@@ -7739,12 +7757,28 @@ def validate_csv_field_cardinality(config, field_definitions, csv_data):
                             + row[config["id_field"]]
                             + " contains more values than the number "
                         )
-                    if config["task"] == "update":
+                    elif config["task"] == "update":
                         message = (
                             'CSV field "'
                             + field_name
                             + '" in record with node ID '
                             + row["node_id"]
+                            + " contains more values than the number "
+                        )
+                    elif config["task"] == "create_terms":
+                        message = (
+                            'CSV field "'
+                            + field_name
+                            + '" in record with term name '
+                            + row["term_name"]
+                            + " contains more values than the number "
+                        )
+                    elif config["task"] == "update_terms":
+                        message = (
+                            'CSV field "'
+                            + field_name
+                            + '" in record with term ID '
+                            + row["term_id"]
                             + " contains more values than the number "
                         )
                     message_2 = (


### PR DESCRIPTION
## Link to Github issue or other discussion

#1036 

## What does this PR do?

This PR fixes a bug where Workbench crashes with an `UnboundLocalError` when running `--check` with the `create_terms` or `update_terms` task if the CSV contains fields with values that exceed the field's cardinality limits.

The `validate_csv_field_cardinality()` function was only handling `create` and `update` tasks when constructing warning messages for cardinality violations. When the task was `create_terms` or `update_terms`, the `message` variable was never assigned, causing a crash when the code attempted to print the warning.

## What changes were made?

Modified `workbench_utils.py` in the `validate_csv_field_cardinality()` function (lines ~7702-7778):

1. Changed the second `if` statement to `elif` for the `update` task condition (lines 7715 and 7742) to create proper conditional chains
2. Added `elif` conditions for `create_terms` task that uses `row["term_name"]` for identification
3. Added `elif` conditions for `update_terms` task that uses `row["term_id"]` for identification

These changes were made in two locations within the function - once for the "field allows 1 value but has multiple" scenario, and once for the "field allows N values but has more than N" scenario.

## How to test / verify this PR?

### Setup
1. Create a `create_terms` task configuration with a CSV that has a field containing multiple delimited values (e.g., `value1;value2`) where the Drupal field only allows a single value (cardinality = 1)

### Expected Behavior

**Before this fix:**
- Workbench crashes with: `UnboundLocalError: cannot access local variable 'message' where it is not associated with a value`

**After this fix:**
- Workbench displays a warning like: `Warning: CSV field "field_name" in record with term name "Example Term" contains more values than the number allowed for that field (1). Workbench will add only the first value.`
- The `--check` completes successfully without crashing

### Verification
Run `./workbench --config your_config.yml --check` and confirm it no longer crashes when CSV data violates field cardinality for taxonomy terms.

## Interested Parties

@mjordan @south-asian-canadian-digital-archive @sacda-ufv

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
