### PR TITLE
Update setup.py to fix failing unit test build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "openpyxl",
         "unidecode",
         "edtf_validate",
-        "typing-extensions",
+        "typing-extensions>=4.14.0",
         "rich",
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
## Link to Github issue or other discussion

> **[Issue 1034](https://github.com/mjordan/islandora_workbench/issues/1034)**
## What does this PR do?

> **Fixes the build failures for unittests.yml due to the wrong version of typing extensions**

## What changes were made?

> **I added a version number to typing extensions in setup.py**

## How to test / verify this PR?

> **The unittest action should pass again.**

## Interested Parties

> _**Replace this text** - name some folks who may be interested, or, if unsure, @mjordan_

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
