### PR TITLE
Running multiple workbenches

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -122,15 +122,26 @@ class WorkbenchConfig:
                 "csv_id_to_node_id_map_path"
             ]
         else:
-            # Add unique identifier to prevent conflicts between multiple workbench instances
-            from workbench_utils import get_config_file_identifier_shortened
-            config_file_id = get_config_file_identifier_shortened(config)
-            base_filename, ext = os.path.splitext(config["csv_id_to_node_id_map_filename"])
-            unique_filename = f"{base_filename}.{config_file_id}{ext}"
-            config["csv_id_to_node_id_map_path"] = os.path.join(
-                config["csv_id_to_node_id_map_dir"],
-                unique_filename,
-            )
+            # Check if we're in recovery mode with a specific session suffix
+            if (config["recovery_mode_starting_from_node_id"] is not False and 
+                config["recovery_mode_session_suffix"] is not False):
+                # Use the provided recovery mode session suffix
+                base_filename, ext = os.path.splitext(config["csv_id_to_node_id_map_filename"])
+                unique_filename = f"{base_filename}.{config['recovery_mode_session_suffix']}{ext}"
+                config["csv_id_to_node_id_map_path"] = os.path.join(
+                    config["csv_id_to_node_id_map_dir"],
+                    unique_filename,
+                )
+            else:
+                # Add unique identifier to prevent conflicts between multiple workbench instances
+                from workbench_utils import get_config_file_identifier_shortened
+                config_file_id = get_config_file_identifier_shortened(config)
+                base_filename, ext = os.path.splitext(config["csv_id_to_node_id_map_filename"])
+                unique_filename = f"{base_filename}.{config_file_id}{ext}"
+                config["csv_id_to_node_id_map_path"] = os.path.join(
+                    config["csv_id_to_node_id_map_dir"],
+                    unique_filename,
+                )
 
         if "path_to_python" in user_mods:
             config["path_to_python"] = user_mods["path_to_python"]
@@ -383,6 +394,7 @@ class WorkbenchConfig:
             "include_password_in_rollback_config_file": False,
             "remove_password_from_config_file": False,
             "recovery_mode_starting_from_node_id": False,
+            "recovery_mode_session_suffix": False,
             "viewer_override_fieldname": "field_viewer_override",
             "check_for_workbench_updates": True,
         }

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -10133,7 +10133,13 @@ def get_csv_from_google_sheet(config):
         sys.exit("Error: " + message)
 
     # Always use unique naming to prevent conflicts between multiple workbench instances
-    config_file_id = get_config_file_identifier_shortened(config)
+    # In recovery mode with session suffix, use that suffix; otherwise generate new unique ID
+    if (config["recovery_mode_starting_from_node_id"] is not False and 
+        config["recovery_mode_session_suffix"] is not False):
+        config_file_id = config["recovery_mode_session_suffix"]
+    else:
+        config_file_id = get_config_file_identifier_shortened(config)
+    
     exported_csv_path = os.path.join(
         config["temp_dir"],
         config["google_sheets_csv_filename"] + "." + config_file_id,
@@ -10173,7 +10179,13 @@ def get_csv_from_excel(config):
         records.append(record)
 
     # Always use unique naming to prevent conflicts between multiple workbench instances
-    config_file_id = get_config_file_identifier_shortened(config)
+    # In recovery mode with session suffix, use that suffix; otherwise generate new unique ID
+    if (config["recovery_mode_starting_from_node_id"] is not False and 
+        config["recovery_mode_session_suffix"] is not False):
+        config_file_id = config["recovery_mode_session_suffix"]
+    else:
+        config_file_id = get_config_file_identifier_shortened(config)
+    
     exported_csv_path = os.path.join(
         config["temp_dir"], config["excel_csv_filename"] + "." + config_file_id
     )
@@ -10211,7 +10223,13 @@ def get_extracted_csv_file_path(config):
         return False
 
     # Always use unique naming to prevent conflicts between multiple workbench instances
-    config_file_id = get_config_file_identifier_shortened(config)
+    # In recovery mode with session suffix, use that suffix; otherwise generate new unique ID
+    if (config["recovery_mode_starting_from_node_id"] is not False and 
+        config["recovery_mode_session_suffix"] is not False):
+        config_file_id = config["recovery_mode_session_suffix"]
+    else:
+        config_file_id = get_config_file_identifier_shortened(config)
+    
     exported_csv_filename = exported_csv_filename + "." + config_file_id
 
     return os.path.join(config["temp_dir"], exported_csv_filename)


### PR DESCRIPTION
## Link to Github issue or other discussion

> https://github.com/mjordan/islandora_workbench/issues/1020
    https://github.com/mjordan/islandora_workbench/issues/999

## What does this PR do?

> This PR allows multiple workbenches to be run simultaneously without interfering with one another, given different input CSVs, allowing for larger amounts of data to be ingested in parallel.

## What changes were made?

> The changes include:
- Added a function (get_config_file_identifier_shortened) in the workbench_utils.py file, that creates a unique suffix to add to the names of files that get created during each session of ingests
- Each ingest session generates a unique identifier using the function, and this suffix is appended to the end of the filename of every file created during that session. This ensures that filenames remain distinct, prevents collisions when multiple ingests run concurrently, and allows users to easily identify which files belong to a specific ingest session. The generated google sheet or excel CSV will include this suffix in the filename (at the very end as it’s attached to the end of the filename), as well as the rollback  file and the SQLite database file (also attached to the end of the filenames).
- Made changes to how recovery mode ingests work.  Now, it takes in another input config setting which is the session identifier (the unique suffix that is attached to the end of the filename that gets created in a session), so that the recovery mode can determine which ingest the recovery mode will be applied to.

## How to test / verify this PR?

> For testing, prepare two separate ingest configuration files (for example, config.yml and config2.yml), each pointing to a different input_csv spreadsheet. Open two terminals on the same workbench directory, and run the ingest process for each configuration file in its own respective terminal at the same time.

Verify that workbench creates a separate tmp files and sqllite database files with session suffix for each session.
Verify that workbench creates a rollback file with the same suffix as the session suffix.
Test and verify that recover mode works independently for each session.

Sample csv and demo objects are available here: https://github.com/Islandora-Devops/islandora_demo_objects

## Interested Parties

> @mjordan @digitalutsc @whikloj 

---

## Checklist

* [X] Before opening this PR, have you opened an issue explaining what you want to to do?
* [X] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
