### PR TITLE
Don't assume field names

### DIFF
--- a/workbench
+++ b/workbench
@@ -1368,18 +1368,7 @@ def update_media() -> None:
             True if the file was successfully deleted or if there was no file attached to this media, False otherwise.
         """
         # Inspect the JSON response to get the file ID
-        for file_field_name in file_fields:
-            if file_field_name in get_media_response_body:
-                try:
-                    file_to_delete = str(
-                        get_media_response_body[file_field_name][0]["target_id"]
-                    )
-                except Exception as e:
-                    logging.warning(
-                        'Unable to get file ID for media "%s" (%s).', media_id, e
-                    )
-                    return True
-                break
+        file_to_delete = find_files_from_media(get_media_response_body)
 
         if file_to_delete:
             # Now we delete the file
@@ -1400,6 +1389,7 @@ def update_media() -> None:
                     file_response.status_code,
                 )
                 return False
+        return True
 
     def delete_media_track_files(
         config: dict, media_id: str, media_type: str, get_media_response_body: dict

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -6189,9 +6189,21 @@ def find_files_from_media(media_response_body: dict) -> Union[str, None]:
     """
     file_ids = []
     for field_id, field_info in media_response_body.items():
-        if len(field_info) == 0 or "target_id" not in field_info[0] or "target_type" not in field_info[0]:
+        if (
+            len(field_info) == 0
+            or "target_id" not in field_info[0]
+            or "target_type" not in field_info[0]
+        ):
             continue
-        file_ids.extend([item["target_id"] for item in field_info if "target_id" in item and "target_type" in item and item["target_type"] == "file"])
+        file_ids.extend(
+            [
+                item["target_id"]
+                for item in field_info
+                if "target_id" in item
+                and "target_type" in item
+                and item["target_type"] == "file"
+            ]
+        )
     set_of_ids = set(file_ids)
 
     return next(iter(set_of_ids)) if len(set_of_ids) > 0 else None

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -6208,6 +6208,7 @@ def find_files_from_media(media_response_body: dict) -> Union[str, None]:
 
     return next(iter(set_of_ids)) if len(set_of_ids) > 0 else None
 
+
 def remove_media_and_file(config: dict, media_id: Union[int, str]) -> Union[int, bool]:
     """Delete a media and the file associated with it.
     Parameters

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -6180,6 +6180,22 @@ def patch_image_alt_text(
     return patch_media_response.status_code
 
 
+def find_files_from_media(media_response_body: dict) -> Union[str, None]:
+    """Given a media JSON response body, return the file IDs associated with it if they have target_type of "file".
+    Parameters:
+        @param media_response_body: The JSON response body from a GET request to a media entity.
+    Returns:
+        @return: A file ID associated with the media or None
+    """
+    file_ids = []
+    for field_id, field_info in media_response_body.items():
+        if len(field_info) == 0 or "target_id" not in field_info[0] or "target_type" not in field_info[0]:
+            continue
+        file_ids.extend([item["target_id"] for item in field_info if "target_id" in item and "target_type" in item and item["target_type"] == "file"])
+    set_of_ids = set(file_ids)
+
+    return next(iter(set_of_ids)) if len(set_of_ids) > 0 else None
+
 def remove_media_and_file(config: dict, media_id: Union[int, str]) -> Union[int, bool]:
     """Delete a media and the file associated with it.
     Parameters
@@ -6214,21 +6230,9 @@ def remove_media_and_file(config: dict, media_id: Union[int, str]) -> Union[int,
         logging.error(message)
         sys.exit("Error: " + message)
 
-    for file_field_name in file_fields:
-        if file_field_name in get_media_response_body:
-            try:
-                file_id = get_media_response_body[file_field_name][0]["target_id"]
-            except Exception as e:
-                logging.error(
-                    "Unable to get file ID for media %s (reason: %s); proceeding to delete media without file.",
-                    media_id,
-                    e,
-                )
-                file_id = None
-            break
+    file_id = find_files_from_media(get_media_response_body)
 
     # Delete the file first.
-    # TODO: file_id might be undefined here if none of the file_fields are in get_media_response_body.
     if file_id is not None:
         file_endpoint = (
             config["host"] + "/entity/file/" + str(file_id) + "?_format=json"
@@ -11853,8 +11857,8 @@ def get_config_file_identifier(config: dict) -> str:
 
 
 def calculate_response_time_trend(config: dict, response_time: int) -> Optional[float]:
-    """Gets the average response time from the most recent 20 HTTP requests."""
-    """Parameters
+    """Gets the average response time from the most recent 20 HTTP requests.
+    Parameters
         ----------
         config : dict
             The configuration settings defined by workbench_config.get_config().


### PR DESCRIPTION
## Link to Github issue or other discussion

https://github.com/mjordan/islandora_workbench/issues/1053

## What does this PR do?

Filter the media JSON body to find any files and use their IDs.

## What changes were made?

Instead of looping through expected field names, we just loop through all fields looking for `"target_type" == "file"` and has a `"target_id"` field. We grab them all, deduplicate and pull the first (there should only be one after deduplication).

## How to test / verify this PR?

Change the file field name for anything different from 
```php
file_fields = [
    "field_media_file",
    "field_media_image",
    "field_media_document",
    "field_media_audio_file",
    "field_media_video_file",
]
```

Then do a "create" task and try to roll it back. It should fail, then try with this PR.

## Interested Parties

@mjordan

---

## Checklist

* [X] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
