### PR TITLE
Write the use_workbench_permissions to the rollback config file.

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -9892,6 +9892,7 @@ def write_rollback_config(config, path_to_rollback_csv_file):
             "host": config["host"],
             "username": config["username"],
             "password": password,
+            "use_workbench_permissions": config["use_workbench_permissions"],
             "input_dir": config["input_dir"],
             "standalone_media_url": config["standalone_media_url"],
             "secure_ssl_only": config["secure_ssl_only"],


### PR DESCRIPTION
## Link to Github issue or other discussion

https://github.com/mjordan/islandora_workbench/issues/1055

## What does this PR do?

Include the `use_workbench_permissions` value in the generated `rollback.yaml` files.

## What changes were made?

As said above

## How to test / verify this PR?

Create a user with non-admin but still enough permissions to ingest data. Ingest an object, then try to use the generated rollback file to rollback the ingest. It will fail as `use_workbench_permissions` does not exist in the `rollback.yaml` file. If you add that key with a value of `True` (which it should be in your original YAML) then it succeeds.

## Interested Parties

@mjordan

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
