### PR TITLE
Improve performance when using a non-admin user

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1993,15 +1993,10 @@ class TestGeneralTests(unittest.TestCase):
         """Sets up a WorkbenchConfig object with a temporary config file for testing and a patch to
         handle calls to verify the 'host' URL."""
         cls.get_patcher = mock.patch(
-            "WorkbenchConfig.requests.sessions.Session.get",
+            "WorkbenchConfig.requests.sessions.Session.request",
             side_effect=mocked_requests_get,
         )
         cls.get_patcher.start()
-        cls.head_patcher = mock.patch(
-            "WorkbenchConfig.requests.sessions.Session.head",
-            side_effect=mocked_requests_get,
-        )
-        cls.head_patcher.start()
 
         with tempfile.NamedTemporaryFile(
             mode="w+", delete=False, suffix=".yml"
@@ -2021,7 +2016,6 @@ class TestGeneralTests(unittest.TestCase):
     def tearDownClass(cls):
         """Stops the patcher and removes the temporary config file."""
         cls.get_patcher.stop()
-        cls.head_patcher.stop()
         if os.path.exists(cls.config_file_name):
             os.remove(cls.config_file_name)
 

--- a/workbench
+++ b/workbench
@@ -333,7 +333,7 @@ def create():
                 print("Warning: " + message)
 
         # Add custom (non-required) CSV fields.
-        entity_fields = get_entity_fields(config, "node", config["content_type"])
+        entity_fields = get_entity_fields(config, "node", config["content_type"]).keys()
         # Only add config['id_field'] to required_fields if it is not a node field.
         required_fields = ["file", "title"]
         if config["id_field"] not in entity_fields:
@@ -2277,7 +2277,7 @@ def create_from_files():
         }
 
         # Add field_model if that field exists in the current content type.
-        entity_fields = get_entity_fields(config, "node", config["content_type"])
+        entity_fields = get_entity_fields(config, "node", config["content_type"]).keys()
         if "field_model" in entity_fields:
             islandora_model = set_model_from_extension(file_name, config)
             node_json["field_model"] = [

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -1181,6 +1181,7 @@ def get_node_title_from_nid(config: dict, node_id: str) -> Union[str, bool]:
     else:
         return False
 
+
 def get_field_definitions(
     config: dict, entity_type: str, bundle_type: str = None
 ) -> dict:
@@ -1208,7 +1209,9 @@ def get_field_definitions(
     if entity_type == "node":
         bundle_type = config["content_type"]
         fields = get_entity_fields(config, entity_type, bundle_type)
-        field_definitions = parse_field_definition(config, fields, entity_type, bundle_type)
+        field_definitions = parse_field_definition(
+            config, fields, entity_type, bundle_type
+        )
 
         # title's configuration is not returned by Drupal so we construct it here. Note: if you add a new key to
         # 'field_definitions', also add it to title's entry here. Also add it for 'title' in the other entity types, below.
@@ -1226,7 +1229,9 @@ def get_field_definitions(
 
     elif entity_type == "taxonomy_term":
         fields = get_entity_fields(config, "taxonomy_term", bundle_type)
-        field_definitions = parse_field_definition(config, fields, "taxonomy_term", bundle_type)
+        field_definitions = parse_field_definition(
+            config, fields, "taxonomy_term", bundle_type
+        )
 
         field_definitions["term_name"] = {
             "entity_type": "taxonomy_term",
@@ -1242,7 +1247,9 @@ def get_field_definitions(
 
     elif entity_type == "media":
         fields = get_entity_fields(config, entity_type, bundle_type)
-        field_definitions = parse_field_definition(config, fields, entity_type, bundle_type)
+        field_definitions = parse_field_definition(
+            config, fields, entity_type, bundle_type
+        )
 
         field_definitions["name"] = {
             "entity_type": "media",
@@ -1259,12 +1266,16 @@ def get_field_definitions(
     elif entity_type == "paragraph":
         fields = get_entity_fields(config, entity_type, bundle_type)
         # NOTE, WIP on #292. Code below copied from 'node' section above, may need modification.
-        field_definitions = parse_field_definition(config, fields, entity_type, bundle_type)
+        field_definitions = parse_field_definition(
+            config, fields, entity_type, bundle_type
+        )
 
     return field_definitions
 
 
-def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_type: str) -> dict:
+def parse_field_definition(
+    config: dict, fields: dict, entity_type: str, bundle_type: str
+) -> dict:
     """Parse a single field's definition into a more digestible format.
     Parameters
     :param config: dict - The configuration settings defined by workbench_config.get_config().
@@ -1276,9 +1287,9 @@ def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_
     field_definitions = {}
     for fieldname, field_info in fields.items():
         field_definitions[fieldname] = {}
-        if config['use_workbench_permissions']:
-            field_config = field_info['config']
-            field_storage_config = field_info['storage_config']
+        if config["use_workbench_permissions"]:
+            field_config = field_info["config"]
+            field_storage_config = field_info["storage_config"]
         else:
             raw_field_config = get_entity_field_config(
                 config, fieldname, entity_type, bundle_type
@@ -1288,13 +1299,13 @@ def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_
             field_storage_config = json.loads(raw_field_storage)
         field_definition = {"entity_type": field_config["entity_type"]}
 
-        if field_config['entity_type'] == 'media':
-            field_definition['media_type'] = field_config['bundle']
+        if field_config["entity_type"] == "media":
+            field_definition["media_type"] = field_config["bundle"]
 
         field_definition["required"] = field_config["required"]
         field_definition["label"] = field_config["label"]
 
-        if 'dependencies' in field_config and 'config' in field_config['dependencies']:
+        if "dependencies" in field_config and "config" in field_config["dependencies"]:
             # Base fields tend to lack the dependencies key.
             vocabularies = [
                 x.replace("taxonomy.vocabulary.", "")
@@ -1306,16 +1317,14 @@ def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_
 
         # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
         if "handler" in field_config["settings"]:
-            field_definition["handler"] = field_config["settings"][
-                "handler"
-            ]
+            field_definition["handler"] = field_config["settings"]["handler"]
         else:
             field_definition["handler"] = None
 
         if "handler_settings" in field_config["settings"]:
-            field_definition["handler_settings"] = field_config[
-                "settings"
-            ]["handler_settings"]
+            field_definition["handler_settings"] = field_config["settings"][
+                "handler_settings"
+            ]
         else:
             field_definition["handler_settings"] = None
 
@@ -1337,12 +1346,10 @@ def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_
             field_definition["target_type"] = None
 
         if (
-                field_storage_config["type"] == "typed_relation"
-                and "rel_types" in field_config["settings"]
+            field_storage_config["type"] == "typed_relation"
+            and "rel_types" in field_config["settings"]
         ):
-            field_definition["typed_relations"] = field_config[
-                "settings"
-            ]["rel_types"]
+            field_definition["typed_relations"] = field_config["settings"]["rel_types"]
 
         if "authority_sources" in field_config["settings"]:
             field_definition["authority_sources"] = list(
@@ -1365,6 +1372,7 @@ def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_
         field_definitions[fieldname] = field_definition
 
     return field_definitions
+
 
 def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> dict:
     """Get all the fields configured on a bundle.
@@ -1423,7 +1431,9 @@ def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> dict:
         else:
             fieldname_prefix = "field.field." + entity_type + "." + bundle_type + "."
             fields = {
-                field_dependency.replace(fieldname_prefix, ""): field_dependency.replace(fieldname_prefix, "")
+                field_dependency.replace(
+                    fieldname_prefix, ""
+                ): field_dependency.replace(fieldname_prefix, "")
                 for field_dependency in node_config_raw["dependencies"]["config"]
                 if field_dependency.startswith(fieldname_prefix)
             }
@@ -1444,6 +1454,7 @@ def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> dict:
         sys.exit("Error: " + message + " See the log for more information.")
 
     return fields
+
 
 def get_required_bundle_fields(
     config: dict, entity_type: str, bundle_type: str

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -798,7 +798,7 @@ def ping_content_type(config: dict) -> int:
         The HTTP response code.
     """
     url = (
-        f"{config['host']}/islandora_workbench_integration/node_actions/entity_display/node/{config['content_type']}"
+        f"{config['host']}/islandora_workbench_integration/node_actions/entity_field_bundle/node/{config['content_type']}"
         if config["use_workbench_permissions"]
         else f"{config['host']}/entity/entity_form_display/node.{config['content_type']}.default?_format=json"
     )
@@ -1181,7 +1181,6 @@ def get_node_title_from_nid(config: dict, node_id: str) -> Union[str, bool]:
     else:
         return False
 
-
 def get_field_definitions(
     config: dict, entity_type: str, bundle_type: str = None
 ) -> dict:
@@ -1209,76 +1208,7 @@ def get_field_definitions(
     if entity_type == "node":
         bundle_type = config["content_type"]
         fields = get_entity_fields(config, entity_type, bundle_type)
-        for fieldname in fields:
-            field_definitions[fieldname] = {}
-            raw_field_config = get_entity_field_config(
-                config, fieldname, entity_type, bundle_type
-            )
-            field_config = json.loads(raw_field_config)
-
-            field_definitions[fieldname]["entity_type"] = field_config["entity_type"]
-            field_definitions[fieldname]["required"] = field_config["required"]
-            field_definitions[fieldname]["label"] = field_config["label"]
-            vocabularies = [
-                x.replace("taxonomy.vocabulary.", "")
-                for x in field_config["dependencies"]["config"]
-                if x.startswith("taxonomy.vocabulary.")
-            ]
-            if len(vocabularies) > 0:
-                field_definitions[fieldname]["vocabularies"] = vocabularies
-            # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
-            if "handler" in field_config["settings"]:
-                field_definitions[fieldname]["handler"] = field_config["settings"][
-                    "handler"
-                ]
-            else:
-                field_definitions[fieldname]["handler"] = None
-            if "handler_settings" in field_config["settings"]:
-                field_definitions[fieldname]["handler_settings"] = field_config[
-                    "settings"
-                ]["handler_settings"]
-            else:
-                field_definitions[fieldname]["handler_settings"] = None
-
-            raw_field_storage = get_entity_field_storage(config, fieldname, entity_type)
-            field_storage = json.loads(raw_field_storage)
-            field_definitions[fieldname]["field_type"] = field_storage["type"]
-            field_definitions[fieldname]["cardinality"] = field_storage["cardinality"]
-            if "max_length" in field_storage["settings"]:
-                field_definitions[fieldname]["max_length"] = field_storage["settings"][
-                    "max_length"
-                ]
-            else:
-                field_definitions[fieldname]["max_length"] = None
-            if "target_type" in field_storage["settings"]:
-                field_definitions[fieldname]["target_type"] = field_storage["settings"][
-                    "target_type"
-                ]
-            else:
-                field_definitions[fieldname]["target_type"] = None
-            if (
-                field_storage["type"] == "typed_relation"
-                and "rel_types" in field_config["settings"]
-            ):
-                field_definitions[fieldname]["typed_relations"] = field_config[
-                    "settings"
-                ]["rel_types"]
-            if "authority_sources" in field_config["settings"]:
-                field_definitions[fieldname]["authority_sources"] = list(
-                    field_config["settings"]["authority_sources"].keys()
-                )
-            else:
-                field_definitions[fieldname]["authority_sources"] = None
-            if "allowed_values" in field_storage["settings"]:
-                field_definitions[fieldname]["allowed_values"] = list(
-                    field_storage["settings"]["allowed_values"].keys()
-                )
-            else:
-                field_definitions[fieldname]["allowed_values"] = None
-            if field_config["field_type"].startswith("text"):
-                field_definitions[fieldname]["formatted_text"] = True
-            else:
-                field_definitions[fieldname]["formatted_text"] = False
+        field_definitions = parse_field_definition(config, fields, entity_type, bundle_type)
 
         # title's configuration is not returned by Drupal so we construct it here. Note: if you add a new key to
         # 'field_definitions', also add it to title's entry here. Also add it for 'title' in the other entity types, below.
@@ -1296,78 +1226,7 @@ def get_field_definitions(
 
     elif entity_type == "taxonomy_term":
         fields = get_entity_fields(config, "taxonomy_term", bundle_type)
-        for fieldname in fields:
-            field_definitions[fieldname] = {}
-            raw_field_config = get_entity_field_config(
-                config, fieldname, entity_type, bundle_type
-            )
-            field_config = json.loads(raw_field_config)
-            field_definitions[fieldname]["entity_type"] = field_config["entity_type"]
-            field_definitions[fieldname]["required"] = field_config["required"]
-            field_definitions[fieldname]["label"] = field_config["label"]
-            raw_vocabularies = [
-                x
-                for x in field_config["dependencies"]["config"]
-                if re.match("^taxonomy.vocabulary.", x)
-            ]
-            if len(raw_vocabularies) > 0:
-                vocabularies = [
-                    x.replace("taxonomy.vocabulary.", "") for x in raw_vocabularies
-                ]
-                field_definitions[fieldname]["vocabularies"] = vocabularies
-            # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
-            if "handler" in field_config["settings"]:
-                field_definitions[fieldname]["handler"] = field_config["settings"][
-                    "handler"
-                ]
-            else:
-                field_definitions[fieldname]["handler"] = None
-            if "handler_settings" in field_config["settings"]:
-                field_definitions[fieldname]["handler_settings"] = field_config[
-                    "settings"
-                ]["handler_settings"]
-            else:
-                field_definitions[fieldname]["handler_settings"] = None
-
-            raw_field_storage = get_entity_field_storage(config, fieldname, entity_type)
-            field_storage = json.loads(raw_field_storage)
-            field_definitions[fieldname]["field_type"] = field_storage["type"]
-            field_definitions[fieldname]["cardinality"] = field_storage["cardinality"]
-            if "max_length" in field_storage["settings"]:
-                field_definitions[fieldname]["max_length"] = field_storage["settings"][
-                    "max_length"
-                ]
-            else:
-                field_definitions[fieldname]["max_length"] = None
-            if "target_type" in field_storage["settings"]:
-                field_definitions[fieldname]["target_type"] = field_storage["settings"][
-                    "target_type"
-                ]
-            else:
-                field_definitions[fieldname]["target_type"] = None
-            if "authority_sources" in field_config["settings"]:
-                field_definitions[fieldname]["authority_sources"] = list(
-                    field_config["settings"]["authority_sources"].keys()
-                )
-            else:
-                field_definitions[fieldname]["authority_sources"] = None
-            if (
-                field_storage["type"] == "typed_relation"
-                and "rel_types" in field_config["settings"]
-            ):
-                field_definitions[fieldname]["typed_relations"] = field_config[
-                    "settings"
-                ]["rel_types"]
-            if "allowed_values" in field_storage["settings"]:
-                field_definitions[fieldname]["allowed_values"] = list(
-                    field_storage["settings"]["allowed_values"].keys()
-                )
-            else:
-                field_definitions[fieldname]["allowed_values"] = None
-            if field_config["field_type"].startswith("text"):
-                field_definitions[fieldname]["formatted_text"] = True
-            else:
-                field_definitions[fieldname]["formatted_text"] = False
+        field_definitions = parse_field_definition(config, fields, "taxonomy_term", bundle_type)
 
         field_definitions["term_name"] = {
             "entity_type": "taxonomy_term",
@@ -1383,83 +1242,7 @@ def get_field_definitions(
 
     elif entity_type == "media":
         fields = get_entity_fields(config, entity_type, bundle_type)
-        for fieldname in fields:
-            field_definitions[fieldname] = {}
-            raw_field_config = get_entity_field_config(
-                config, fieldname, entity_type, bundle_type
-            )
-            field_config = json.loads(raw_field_config)
-            field_definitions[fieldname]["media_type"] = bundle_type
-            field_definitions[fieldname]["field_type"] = field_config["field_type"]
-            field_definitions[fieldname]["required"] = field_config["required"]
-            field_definitions[fieldname]["label"] = field_config["label"]
-            raw_vocabularies = [
-                x
-                for x in field_config["dependencies"]["config"]
-                if re.match("^taxonomy.vocabulary.", x)
-            ]
-            if len(raw_vocabularies) > 0:
-                vocabularies = [
-                    x.replace("taxonomy.vocabulary.", "") for x in raw_vocabularies
-                ]
-                field_definitions[fieldname]["vocabularies"] = vocabularies
-            # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
-            if "handler" in field_config["settings"]:
-                field_definitions[fieldname]["handler"] = field_config["settings"][
-                    "handler"
-                ]
-            else:
-                field_definitions[fieldname]["handler"] = None
-            if "handler_settings" in field_config["settings"]:
-                field_definitions[fieldname]["handler_settings"] = field_config[
-                    "settings"
-                ]["handler_settings"]
-            else:
-                field_definitions[fieldname]["handler_settings"] = None
-            if "file_extensions" in field_config["settings"]:
-                field_definitions[fieldname]["file_extensions"] = field_config[
-                    "settings"
-                ]["file_extensions"]
-
-            raw_field_storage = get_entity_field_storage(config, fieldname, entity_type)
-            field_storage = json.loads(raw_field_storage)
-            field_definitions[fieldname]["field_type"] = field_storage["type"]
-            field_definitions[fieldname]["cardinality"] = field_storage["cardinality"]
-            if "max_length" in field_storage["settings"]:
-                field_definitions[fieldname]["max_length"] = field_storage["settings"][
-                    "max_length"
-                ]
-            else:
-                field_definitions[fieldname]["max_length"] = None
-            if "target_type" in field_storage["settings"]:
-                field_definitions[fieldname]["target_type"] = field_storage["settings"][
-                    "target_type"
-                ]
-            else:
-                field_definitions[fieldname]["target_type"] = None
-            if (
-                field_storage["type"] == "typed_relation"
-                and "rel_types" in field_config["settings"]
-            ):
-                field_definitions[fieldname]["typed_relations"] = field_config[
-                    "settings"
-                ]["rel_types"]
-            if "authority_sources" in field_config["settings"]:
-                field_definitions[fieldname]["authority_sources"] = list(
-                    field_config["settings"]["authority_sources"].keys()
-                )
-            else:
-                field_definitions[fieldname]["authority_sources"] = None
-            if "allowed_values" in field_storage["settings"]:
-                field_definitions[fieldname]["allowed_values"] = list(
-                    field_storage["settings"]["allowed_values"].keys()
-                )
-            else:
-                field_definitions[fieldname]["allowed_values"] = None
-            if field_config["field_type"].startswith("text"):
-                field_definitions[fieldname]["formatted_text"] = True
-            else:
-                field_definitions[fieldname]["formatted_text"] = False
+        field_definitions = parse_field_definition(config, fields, entity_type, bundle_type)
 
         field_definitions["name"] = {
             "entity_type": "media",
@@ -1475,85 +1258,115 @@ def get_field_definitions(
 
     elif entity_type == "paragraph":
         fields = get_entity_fields(config, entity_type, bundle_type)
-        for fieldname in fields:
-            # NOTE, WIP on #292. Code below copied from 'node' section above, may need modification.
-            field_definitions[fieldname] = {}
-            raw_field_config = get_entity_field_config(
-                config, fieldname, entity_type, bundle_type
-            )
-            field_config = json.loads(raw_field_config)
-
-            field_definitions[fieldname]["entity_type"] = field_config["entity_type"]
-            field_definitions[fieldname]["required"] = field_config["required"]
-            field_definitions[fieldname]["label"] = field_config["label"]
-            raw_vocabularies = [
-                x
-                for x in field_config["dependencies"]["config"]
-                if re.match("^taxonomy.vocabulary.", x)
-            ]
-            if len(raw_vocabularies) > 0:
-                vocabularies = [
-                    x.replace("taxonomy.vocabulary.", "") for x in raw_vocabularies
-                ]
-                field_definitions[fieldname]["vocabularies"] = vocabularies
-            # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
-            if "handler" in field_config["settings"]:
-                field_definitions[fieldname]["handler"] = field_config["settings"][
-                    "handler"
-                ]
-            else:
-                field_definitions[fieldname]["handler"] = None
-            if "handler_settings" in field_config["settings"]:
-                field_definitions[fieldname]["handler_settings"] = field_config[
-                    "settings"
-                ]["handler_settings"]
-            else:
-                field_definitions[fieldname]["handler_settings"] = None
-
-            raw_field_storage = get_entity_field_storage(config, fieldname, entity_type)
-            field_storage = json.loads(raw_field_storage)
-            field_definitions[fieldname]["field_type"] = field_storage["type"]
-            field_definitions[fieldname]["cardinality"] = field_storage["cardinality"]
-            if "max_length" in field_storage["settings"]:
-                field_definitions[fieldname]["max_length"] = field_storage["settings"][
-                    "max_length"
-                ]
-            else:
-                field_definitions[fieldname]["max_length"] = None
-            if "target_type" in field_storage["settings"]:
-                field_definitions[fieldname]["target_type"] = field_storage["settings"][
-                    "target_type"
-                ]
-            else:
-                field_definitions[fieldname]["target_type"] = None
-            if (
-                field_storage["type"] == "typed_relation"
-                and "rel_types" in field_config["settings"]
-            ):
-                field_definitions[fieldname]["typed_relations"] = field_config[
-                    "settings"
-                ]["rel_types"]
-            if "authority_sources" in field_config["settings"]:
-                field_definitions[fieldname]["authority_sources"] = list(
-                    field_config["settings"]["authority_sources"].keys()
-                )
-            else:
-                field_definitions[fieldname]["authority_sources"] = None
-            if "allowed_values" in field_storage["settings"]:
-                field_definitions[fieldname]["allowed_values"] = list(
-                    field_storage["settings"]["allowed_values"].keys()
-                )
-            else:
-                field_definitions[fieldname]["allowed_values"] = None
-            if field_config["field_type"].startswith("text"):
-                field_definitions[fieldname]["formatted_text"] = True
-            else:
-                field_definitions[fieldname]["formatted_text"] = False
+        # NOTE, WIP on #292. Code below copied from 'node' section above, may need modification.
+        field_definitions = parse_field_definition(config, fields, entity_type, bundle_type)
 
     return field_definitions
 
 
-def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> list:
+def parse_field_definition(config: dict, fields: dict, entity_type: str, bundle_type: str) -> dict:
+    """Parse a single field's definition into a more digestible format.
+    Parameters
+    :param config: dict - The configuration settings defined by workbench_config.get_config().
+    :param fields: dict - The field names and information or just names. From get_entity_fields().
+    :param entity_type: string - One of 'node', 'media', 'taxonomy_term', or 'paragraph'.
+    :param bundle_type: string - The bundle type of the entity.
+    :return: dict - A dictionary with the field's properties in a more digestible format.
+    """
+    field_definitions = {}
+    for fieldname, field_info in fields.items():
+        field_definitions[fieldname] = {}
+        if config['use_workbench_permissions']:
+            field_config = field_info['config']
+            field_storage_config = field_info['storage_config']
+        else:
+            raw_field_config = get_entity_field_config(
+                config, fieldname, entity_type, bundle_type
+            )
+            field_config = json.loads(raw_field_config)
+            raw_field_storage = get_entity_field_storage(config, fieldname, entity_type)
+            field_storage_config = json.loads(raw_field_storage)
+        field_definition = {"entity_type": field_config["entity_type"]}
+
+        if field_config['entity_type'] == 'media':
+            field_definition['media_type'] = field_config['bundle']
+
+        field_definition["required"] = field_config["required"]
+        field_definition["label"] = field_config["label"]
+
+        if 'dependencies' in field_config and 'config' in field_config['dependencies']:
+            # Base fields tend to lack the dependencies key.
+            vocabularies = [
+                x.replace("taxonomy.vocabulary.", "")
+                for x in field_config["dependencies"]["config"]
+                if x.startswith("taxonomy.vocabulary.")
+            ]
+            if len(vocabularies) > 0:
+                field_definition["vocabularies"] = vocabularies
+
+        # Reference 'handler' could be nothing, 'default:taxonomy_term' (or some other entity type), or 'views'.
+        if "handler" in field_config["settings"]:
+            field_definition["handler"] = field_config["settings"][
+                "handler"
+            ]
+        else:
+            field_definition["handler"] = None
+
+        if "handler_settings" in field_config["settings"]:
+            field_definition["handler_settings"] = field_config[
+                "settings"
+            ]["handler_settings"]
+        else:
+            field_definition["handler_settings"] = None
+
+        field_definition["field_type"] = field_storage_config["type"]
+        field_definition["cardinality"] = field_storage_config["cardinality"]
+
+        if "max_length" in field_storage_config["settings"]:
+            field_definition["max_length"] = field_storage_config["settings"][
+                "max_length"
+            ]
+        else:
+            field_definition["max_length"] = None
+
+        if "target_type" in field_storage_config["settings"]:
+            field_definition["target_type"] = field_storage_config["settings"][
+                "target_type"
+            ]
+        else:
+            field_definition["target_type"] = None
+
+        if (
+                field_storage_config["type"] == "typed_relation"
+                and "rel_types" in field_config["settings"]
+        ):
+            field_definition["typed_relations"] = field_config[
+                "settings"
+            ]["rel_types"]
+
+        if "authority_sources" in field_config["settings"]:
+            field_definition["authority_sources"] = list(
+                field_config["settings"]["authority_sources"].keys()
+            )
+        else:
+            field_definition["authority_sources"] = None
+
+        if "allowed_values" in field_storage_config["settings"]:
+            field_definition["allowed_values"] = list(
+                field_storage_config["settings"]["allowed_values"].keys()
+            )
+        else:
+            field_definition["allowed_values"] = None
+
+        if field_config["field_type"].startswith("text"):
+            field_definition["formatted_text"] = True
+        else:
+            field_definition["formatted_text"] = False
+        field_definitions[fieldname] = field_definition
+
+    return field_definitions
+
+def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> dict:
     """Get all the fields configured on a bundle.
 
     Parameters
@@ -1567,8 +1380,9 @@ def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> list:
 
     Returns
     -------
-    list
-        A list with field names, e.g. ['field_name1', 'field_name2'].
+    dict
+        If use_workbench_permissions is True, returns a dictionary with field names as keys, second level has keys 'config' and 'storage_config' with the Drupal data.
+        Otherwise returns a dict with field names as keys and field names as values, e.g. {'field_name1': 'field_name1', 'field_name2': 'field_name2'}.
 
     """
     if ping_content_type(config) == 404:
@@ -1581,7 +1395,7 @@ def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> list:
         logging.error(message)
         sys.exit("Error: " + message)
     fields_endpoint = (
-        f"{config['host']}/islandora_workbench_integration/node_actions/entity_display/{entity_type}/{bundle_type}"
+        f"{config['host']}/islandora_workbench_integration/node_actions/entity_field_bundle/{entity_type}/{bundle_type}"
         if config["use_workbench_permissions"]
         else f"{config['host']}/entity/entity_form_display/{entity_type}.{bundle_type}.default?_format=json"
     )
@@ -1599,17 +1413,20 @@ def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> list:
         # If this request confirms the vocabulary exists, its OK to make some assumptions
         # about what fields it has.
         if fallback_bundle_type_response.status_code == 200:
-            return []
+            return {}
 
-    fields = []
+    fields = {}
     if bundle_type_response.status_code == 200:
         node_config_raw = bundle_type_response.json()
-        fieldname_prefix = "field.field." + entity_type + "." + bundle_type + "."
-        fields = [
-            field_dependency.replace(fieldname_prefix, "")
-            for field_dependency in node_config_raw["dependencies"]["config"]
-            if field_dependency.startswith(fieldname_prefix)
-        ]
+        if config["use_workbench_permissions"]:
+            fields = node_config_raw
+        else:
+            fieldname_prefix = "field.field." + entity_type + "." + bundle_type + "."
+            fields = {
+                field_dependency.replace(fieldname_prefix, ""): field_dependency.replace(fieldname_prefix, "")
+                for field_dependency in node_config_raw["dependencies"]["config"]
+                if field_dependency.startswith(fieldname_prefix)
+            }
     else:
         message = "Workbench cannot retrieve field definitions from Drupal."
         message_detail = ""
@@ -1627,7 +1444,6 @@ def get_entity_fields(config: dict, entity_type: str, bundle_type: str) -> list:
         sys.exit("Error: " + message + " See the log for more information.")
 
     return fields
-
 
 def get_required_bundle_fields(
     config: dict, entity_type: str, bundle_type: str

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -1298,8 +1298,8 @@ def parse_field_definition(
             field_storage_config = json.loads(raw_field_storage)
         # Currently skip all base fields as they screw up required field checks.
         if (
-                "is_base_field" in field_config.keys()
-                and field_config["is_base_field"] is True
+            "is_base_field" in field_config.keys()
+            and field_config["is_base_field"] is True
         ):
             continue
         field_definitions[fieldname] = {}

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -1286,7 +1286,6 @@ def parse_field_definition(
     """
     field_definitions = {}
     for fieldname, field_info in fields.items():
-        field_definitions[fieldname] = {}
         if config["use_workbench_permissions"]:
             field_config = field_info["config"]
             field_storage_config = field_info["storage_config"]
@@ -1297,6 +1296,13 @@ def parse_field_definition(
             field_config = json.loads(raw_field_config)
             raw_field_storage = get_entity_field_storage(config, fieldname, entity_type)
             field_storage_config = json.loads(raw_field_storage)
+        # Currently skip all base fields as they screw up required field checks.
+        if (
+                "is_base_field" in field_config.keys()
+                and field_config["is_base_field"] is True
+        ):
+            continue
+        field_definitions[fieldname] = {}
         field_definition = {"entity_type": field_config["entity_type"]}
 
         if field_config["entity_type"] == "media":


### PR DESCRIPTION
## Link to Github issue or other discussion

#1061 

## What does this PR do?

Reduces multiple requests for field configuration data to a single request for an entity/bundle

## What changes were made?

1. Along with changes in https://github.com/mjordan/islandora_workbench_integration/pull/46 
1. Changes the return type of `get_entity_fields()` from `list` to `dict` with `field_name: field_info`, 
     * when using an administrator user `field_info == field_name` (i.e. `{"field_some": "field_some", "field_other": "field_other"}`)
     * when using `use_workbench_permission` `field_info = {'config': <field configuration>, 'storage_config': <field storage configuration>}`
1. Refactors the common parts of in `get_field_definition()` for each entity type to reduce the function.

## How to test / verify this PR?

Run a `--check` of any action with both an administrator user and a non-admin user. There should be no difference except for (hopefully) some improvement in speed.

I am fixing some orphans and using a simple config like this
```yaml
task: update
host: https://dams-ng.lib.umanitoba.ca
#username: workbench_user
#password: <workbench_user_password>
#use_workbench_permissions: True
username: jwhiklo
password: <jwhiklo_password>
input_dir: /Users/jaredwhiklo/www/DAM2/islandora_workbench_dup
input_csv: test.csv
include_password_in_rollback_config_file: true
id_field: ID
secure_ssl_only: False
csv_field_templates:
 - field_member_of: 233
protected_vocabularies:
 - islandora_model
 - islandora_display
 - islandora_media_use
ignore_csv_columns:
 - 'RELS_EXT_isMemberOf_uri_ms'
 - 'RELS_EXT_isPageNumber_literal_ms'
 - 'RELS_EXT_isSequenceNumber_literal_ms'
 - 'related_item_title_ms'
 - 'RELS_EXT_dateIssued_literal_ms'
 - 'RELS_EXT_hasModel_uri_ms'
 - 'date_original'
```
and a csv with just the `node_id` of the object's to fix the `field_member_of` on 

Run as my user (administrator)

```bash
[/Users/jaredwhiklo/www/DAM2/islandora_workbench_dup] 
> time python workbench --config=fix_test.yaml --check
OK, connection to Drupal at https://dams-ng.lib.umanitoba.ca verified. Ignoring SSL certificates.
OK, configuration file has all required values (did not check for optional values).
OK, CSV file /Users/jaredwhiklo/www/DAM2/islandora_workbench_dup/test.csv found.
OK, all 14 rows in the CSV file have the same number of columns as there are headers (2).
OK, CSV column headers match Drupal field names.
Configuration and input data appear to be valid. However, you should review your Workbench log after running --check.
python workbench --config=fix_test.yaml --check  3.59s user 0.45s system 9% cpu 43.563 total
```

Run as workbench_user

```bash
> time python workbench --config=fix_test.yaml --check
OK, connection to Drupal at https://dams-ng.lib.umanitoba.ca verified. Ignoring SSL certificates.
OK, configuration file has all required values (did not check for optional values).
OK, CSV file /Users/jaredwhiklo/www/DAM2/islandora_workbench_dup/test.csv found.
OK, all 14 rows in the CSV file have the same number of columns as there are headers (2).
OK, CSV column headers match Drupal field names.
Configuration and input data appear to be valid. However, you should review your Workbench log after running --check.
python workbench --config=fix_test.yaml --check  0.71s user 0.17s system 20% cpu 4.238 total
```

## Interested Parties

@mjordan

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
      **I have not done this, but I could add some simple tests with pulled data from our development server.**
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
