### PR TITLE
Skip serializing the partially missing references

### DIFF
--- a/tests/field_tests_values.py
+++ b/tests/field_tests_values.py
@@ -8,6 +8,8 @@ import sys
 import os
 import unittest
 
+from unittest import mock
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import workbench_fields
 
@@ -90,6 +92,114 @@ class TestAuthorityLinkField(unittest.TestCase):
             self.assertRegex(
                 str(message.output), r"xxx.*not a valid Authority Link field value"
             )
+
+
+def mocked_request_ping_taxonomy_term(*args, **kwargs):
+    """Don't actually do the ping, just assume they exist."""
+    return True
+
+
+class TestEntityReferenceField(unittest.TestCase):
+
+    @mock.patch(
+        "workbench_fields.ping_term", side_effect=mocked_request_ping_taxonomy_term
+    )
+    def test_entity_reference_field_validate_single(self, mocked_request):
+        input = [
+            {
+                "target_id": 105,
+                "target_type": "taxonomy_term",
+                "target_uuid": "8dfca720-06ba-4e3b-96dd-9930fec91480",
+                "url": "\/taxonomy\/term\/105",
+            }
+        ]
+        field_definitions = {
+            "field_subject": {
+                "entity_type": "node",
+                "field_type": "entity_reference",
+                "target_type": "taxonomy_term",
+            }
+        }
+        config = {
+            "task": "create",
+            "host": "http://example.host",
+            "export_csv_term_mode": "tid",
+            "subdelimiter": "|",
+        }
+        field = workbench_fields.EntityReferenceField()
+        output = field.serialize(config, field_definitions, "field_subject", input)
+        self.assertEqual("105", output)
+
+    @mock.patch(
+        "workbench_fields.ping_term", side_effect=mocked_request_ping_taxonomy_term
+    )
+    def test_entity_reference_field_validate_two(self, mocked_request):
+        input = [
+            {
+                "target_id": 105,
+                "target_type": "taxonomy_term",
+                "target_uuid": "8dfca720-06ba-4e3b-96dd-9930fec91480",
+                "url": "\/taxonomy\/term\/105",
+            },
+            {
+                "target_id": 251,
+                "target_type": "taxonomy_term",
+                "target_uuid": "22cbdcf1-a895-4414-848c-47831af77663",
+                "url": "\/taxonomy\/term\/251",
+            },
+        ]
+        field_definitions = {
+            "field_subject": {
+                "entity_type": "node",
+                "field_type": "entity_reference",
+                "target_type": "taxonomy_term",
+            }
+        }
+        config = {
+            "task": "create",
+            "host": "http://example.host",
+            "export_csv_term_mode": "tid",
+            "subdelimiter": "|",
+        }
+        field = workbench_fields.EntityReferenceField()
+        output = field.serialize(config, field_definitions, "field_subject", input)
+        self.assertEqual("105|251", output)
+
+    @mock.patch(
+        "workbench_fields.ping_term", side_effect=mocked_request_ping_taxonomy_term
+    )
+    def test_entity_reference_field_validate_not_exist(self, mocked_request):
+        input = [
+            {
+                "target_id": 105,
+                "target_type": "taxonomy_term",
+                "target_uuid": "8dfca720-06ba-4e3b-96dd-9930fec91480",
+                "url": "\/taxonomy\/term\/105",
+            },
+            {
+                "target_id": 251,
+                "target_type": "taxonomy_term",
+                "target_uuid": "22cbdcf1-a895-4414-848c-47831af77663",
+                "url": "\/taxonomy\/term\/251",
+            },
+            {"target_id": 120},
+        ]
+        field_definitions = {
+            "field_subject": {
+                "entity_type": "node",
+                "field_type": "entity_reference",
+                "target_type": "taxonomy_term",
+            }
+        }
+        config = {
+            "task": "create",
+            "host": "http://example.host",
+            "export_csv_term_mode": "tid",
+            "subdelimiter": "|",
+        }
+        field = workbench_fields.EntityReferenceField()
+        output = field.serialize(config, field_definitions, "field_subject", input)
+        self.assertEqual("105|251", output)
 
 
 if __name__ == "__main__":

--- a/workbench_fields.py
+++ b/workbench_fields.py
@@ -1089,6 +1089,9 @@ class EntityReferenceField(WorkbenchField):
 
         subvalues = list()
         for subvalue in field_data:
+            if "target_type" not in subvalue:
+                # No target_type means the target item may have been deleted, so skip it.
+                continue
             if (
                 config["export_csv_term_mode"] == "name"
                 and subvalue["target_type"] == "taxonomy_term"


### PR DESCRIPTION
## Link to Github issue or other discussion

https://github.com/mjordan/islandora_workbench/issues/1073

## What does this PR do?

If the JSON of a entity reference field does not have a `target_type` key, then skip it. In past this has occurred for @rosiel when she had deleted a taxonomy term before removing it from all items.

## What changes were made?

Skip entity reference values without a `target_type` key

## How to test / verify this PR?

Unit test is included

## Interested Parties

@mjordan

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
