### PR TITLE
Read hostname from environment variable to make changes easier

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,6 +9,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      WB_INTEGRATION_TEST_HOST: ${{ vars.WB_INTEGRATION_TEST_HOST || 'https://islandora.io' }}
 
     steps:
 

--- a/tests/workbench_test_class.py
+++ b/tests/workbench_test_class.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from workbench_utils import get_nid_from_url_without_config, value_is_numeric
 
 """ The full hostname and scheme of the Drupal installation for the integration tests. """
-WB_INTEGRATION_TEST_HOST = "https://islandora.io"
+WB_INTEGRATION_TEST_HOST = os.getenv("WB_INTEGRATION_TEST_HOST", "https://islandora.io")
 
 
 def get_workbench_dir(starting_path: str):


### PR DESCRIPTION
Also change default

Read the hostname to run the tests against from an environment variable, and also sets that environment variable from a Github repository variable to allow changing the domain without code changes.

If you set a repository variable of `WB_INTEGRATION_TEST_HOST` to the full scheme and hostname, it will be passed into the test structure and run against that hostname.

Also you can set an environment variable when running the tests manually to test against different hosts.

## Interested Parties

@mjordan

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
