### PR TITLE
Add tilde (~) home directory expansion for paths in configuration files

### DIFF
--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -10,6 +10,7 @@ from rich.table import Table
 class WorkbenchConfig:
     def __init__(self, args):
         self.args = args
+        self.args.config = os.path.expanduser(self.args.config)
         self.user_mods = self.get_user_config()
         if "password" not in self.user_mods and "username" in self.user_mods:
             self.user_mods["password"] = self.get_credentials()
@@ -262,6 +263,9 @@ class WorkbenchConfig:
             "path_to_workbench_script",
             "path_to_python",
             "check_lock_file_path",
+            "csv_rows_to_process",
+            "rollback_csv_file_path",
+            "rollback_config_file_path",
         ]
         for _key in _path_keys:
             if _key in config and isinstance(config[_key], str):

--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -1,5 +1,6 @@
 """Class to encapsulate Workbench configuration definitions."""
 
+import shlex
 import tempfile
 from getpass import getpass
 from workbench_utils import *
@@ -245,7 +246,7 @@ class WorkbenchConfig:
 
         config["config_file"] = self.args.config
 
-        _path_keys = [
+        _expanduser_keys = [
             "input_dir",
             "input_csv",
             "log_file_path",
@@ -263,19 +264,24 @@ class WorkbenchConfig:
             "path_to_workbench_script",
             "path_to_python",
             "check_lock_file_path",
-            "csv_rows_to_process",
             "rollback_csv_file_path",
             "rollback_config_file_path",
         ]
-        for _key in _path_keys:
+        for _key in _expanduser_keys:
             if _key in config and isinstance(config[_key], str):
                 config[_key] = os.path.expanduser(config[_key])
 
         def _expand_script(s):
-            if " " in s:
-                interpreter, path = s.split(" ", 1)
-                return interpreter + " " + os.path.expanduser(path)
-            return os.path.expanduser(s)
+            if "~" not in s:
+                return s
+            try:
+                tokens = shlex.split(s)
+            except ValueError:
+                return s
+            expanded = [
+                os.path.expanduser(t) if t.startswith("~") else t for t in tokens
+            ]
+            return " ".join(expanded)
 
         _list_script_keys = [
             "bootstrap",

--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -61,17 +61,20 @@ class WorkbenchConfig:
                 "username" not in password_cfg
                 and "credentials_file_path" in password_cfg
             ):
-                if os.path.exists(password_cfg["credentials_file_path"]) is False:
+                credentials_file_path = os.path.expanduser(
+                    password_cfg["credentials_file_path"]
+                )
+                if os.path.exists(credentials_file_path) is False:
                     message = (
                         'Error: Credentials file "'
-                        + password_cfg["credentials_file_path"]
+                        + credentials_file_path
                         + '" not found.'
                     )
                     logging.error(message)
                     sys.exit(message)
                 else:
                     # We open the file to determine how many lines it contains.
-                    with open(password_cfg["credentials_file_path"], "r") as stream:
+                    with open(credentials_file_path, "r") as stream:
                         tmp_credentials_content_file = stream.read()
                         tmp_credentials_content = (
                             tmp_credentials_content_file.splitlines()
@@ -85,19 +88,19 @@ class WorkbenchConfig:
 
                     # We open the file here to read its YAML.
                     credentials_yaml = YAML()
-                    with open(password_cfg["credentials_file_path"], "r") as stream:
+                    with open(credentials_file_path, "r") as stream:
                         try:
                             if encrypted is True:
                                 if "credentials_key_file_path" in password_cfg:
                                     credentials_key_file_path = os.path.abspath(
-                                        password_cfg["credentials_key_file_path"]
+                                        os.path.expanduser(
+                                            password_cfg["credentials_key_file_path"]
+                                        )
                                     )
                                 else:
                                     credentials_key_file_path = None
                                 decrypted_credentials = self.decrypt_credentials_file(
-                                    os.path.abspath(
-                                        password_cfg["credentials_file_path"]
-                                    ),
+                                    os.path.abspath(credentials_file_path),
                                     credentials_key_file_path,
                                 )
                                 credentials = credentials_yaml.load(
@@ -115,7 +118,7 @@ class WorkbenchConfig:
                                 )
                         except YAMLError as exc:
                             print(
-                                f'There appears to be a YAML syntax error in your credentials file, {password_cfg["credentials_file_path"]}. See workbench.log for details.'
+                                f'There appears to be a YAML syntax error in your credentials file, {credentials_file_path}. See workbench.log for details.'
                             )
                             logging.basicConfig(
                                 filename="workbench.log",
@@ -240,6 +243,57 @@ class WorkbenchConfig:
             config["paged_content_page_content_type"] = config["content_type"]
 
         config["config_file"] = self.args.config
+
+        _path_keys = [
+            "input_dir",
+            "input_csv",
+            "log_file_path",
+            "output_csv",
+            "credentials_file_path",
+            "credentials_key_file_path",
+            "export_csv_file_path",
+            "export_file_directory",
+            "contact_sheet_output_dir",
+            "contact_sheet_css_path",
+            "rollback_dir",
+            "csv_id_to_node_id_map_dir",
+            "csv_id_to_node_id_map_path",
+            "sqlite_db_filename",
+            "path_to_workbench_script",
+            "path_to_python",
+            "check_lock_file_path",
+        ]
+        for _key in _path_keys:
+            if _key in config and isinstance(config[_key], str):
+                config[_key] = os.path.expanduser(config[_key])
+
+        def _expand_script(s):
+            if " " in s:
+                interpreter, path = s.split(" ", 1)
+                return interpreter + " " + os.path.expanduser(path)
+            return os.path.expanduser(s)
+
+        _list_script_keys = [
+            "bootstrap",
+            "shutdown",
+            "node_post_create",
+            "node_post_update",
+            "media_post_create",
+            "run_scripts",
+        ]
+        for _key in _list_script_keys:
+            if _key in config and isinstance(config[_key], list):
+                config[_key] = [
+                    _expand_script(s) if isinstance(s, str) else s
+                    for s in config[_key]
+                ]
+
+        if "preprocessors" in config and isinstance(config["preprocessors"], list):
+            for _entry in config["preprocessors"]:
+                if isinstance(_entry, dict):
+                    for _field, _script in _entry.items():
+                        if isinstance(_script, str):
+                            _entry[_field] = _expand_script(_script)
 
         return config
 

--- a/WorkbenchConfig.py
+++ b/WorkbenchConfig.py
@@ -119,7 +119,7 @@ class WorkbenchConfig:
                                 )
                         except YAMLError as exc:
                             print(
-                                f'There appears to be a YAML syntax error in your credentials file, {credentials_file_path}. See workbench.log for details.'
+                                f"There appears to be a YAML syntax error in your credentials file, {credentials_file_path}. See workbench.log for details."
                             )
                             logging.basicConfig(
                                 filename="workbench.log",
@@ -288,8 +288,7 @@ class WorkbenchConfig:
         for _key in _list_script_keys:
             if _key in config and isinstance(config[_key], list):
                 config[_key] = [
-                    _expand_script(s) if isinstance(s, str) else s
-                    for s in config[_key]
+                    _expand_script(s) if isinstance(s, str) else s for s in config[_key]
                 ]
 
         if "preprocessors" in config and isinstance(config["preprocessors"], list):

--- a/tests/assets/WorkbenchConfig_test/config_03_expanduser_paths.yml
+++ b/tests/assets/WorkbenchConfig_test/config_03_expanduser_paths.yml
@@ -1,0 +1,19 @@
+task: create
+host: https://islandora.dev
+username: admin
+password: password
+secure_ssl_only: false
+input_dir: ~/workbench_input
+log_file_path: ~/workbench.log
+export_csv_file_path: ~/export.csv
+rollback_dir: ~/rollback
+bootstrap:
+  - ~/scripts/bootstrap.sh
+  - python ~/scripts/bootstrap.py
+shutdown:
+  - ~/scripts/shutdown.sh
+node_post_create:
+  - ~/scripts/post_create.sh
+preprocessors:
+  - field_one: ~/scripts/preprocess.sh
+  - field_two: python ~/scripts/preprocess.py

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -2193,5 +2193,16 @@ class TestGeneralTests(unittest.TestCase):
         self.assertEqual("islandora_object", config["paged_content_page_content_type"])
 
 
+class TestExpandUserInUtils(unittest.TestCase):
+    def test_check_file_exists_expands_tilde(self):
+        with mock.patch(
+            "workbench_utils.os.path.isfile", return_value=True
+        ) as mock_isfile:
+            workbench_utils.check_file_exists({}, "~/test_file.txt")
+        called_path = mock_isfile.call_args[0][0]
+        self.assertFalse(called_path.startswith("~"))
+        self.assertEqual(called_path, os.path.expanduser("~/test_file.txt"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -225,7 +225,6 @@ class TestWorkbenchConfig(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, error_message) as exit_return:
                 test_config_obj = WorkbenchConfig(args)
 
-
     def test_get_config_expanduser_paths(self):
         test_file_name = (
             "tests/assets/WorkbenchConfig_test/config_03_expanduser_paths.yml"

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -226,5 +226,59 @@ class TestWorkbenchConfig(unittest.TestCase):
                 test_config_obj = WorkbenchConfig(args)
 
 
+    def test_get_config_expanduser_paths(self):
+        test_file_name = (
+            "tests/assets/WorkbenchConfig_test/config_03_expanduser_paths.yml"
+        )
+
+        args = self.parser.parse_args(["--config", test_file_name])
+
+        with patch("WorkbenchConfig.logging") as mocked_logging:
+            mocked_logging.return_value = None
+
+            test_config_obj = WorkbenchConfig(args)
+            config = test_config_obj.get_config()
+
+            for key, tilde_val in [
+                ("input_dir", "~/workbench_input"),
+                ("log_file_path", "~/workbench.log"),
+                ("export_csv_file_path", "~/export.csv"),
+                ("rollback_dir", "~/rollback"),
+            ]:
+                self.assertFalse(config[key].startswith("~"), f"{key} still contains ~")
+                self.assertEqual(
+                    os.path.normpath(config[key]),
+                    os.path.normpath(os.path.expanduser(tilde_val)),
+                )
+
+            # List-based script paths.
+            self.assertEqual(
+                os.path.normpath(config["bootstrap"][0]),
+                os.path.normpath(os.path.expanduser("~/scripts/bootstrap.sh")),
+            )
+            self.assertEqual(
+                config["bootstrap"][1],
+                "python " + os.path.expanduser("~/scripts/bootstrap.py"),
+            )
+            self.assertEqual(
+                os.path.normpath(config["shutdown"][0]),
+                os.path.normpath(os.path.expanduser("~/scripts/shutdown.sh")),
+            )
+            self.assertEqual(
+                os.path.normpath(config["node_post_create"][0]),
+                os.path.normpath(os.path.expanduser("~/scripts/post_create.sh")),
+            )
+
+            # Preprocessor dicts.
+            self.assertEqual(
+                os.path.normpath(config["preprocessors"][0]["field_one"]),
+                os.path.normpath(os.path.expanduser("~/scripts/preprocess.sh")),
+            )
+            self.assertEqual(
+                config["preprocessors"][1]["field_two"],
+                "python " + os.path.expanduser("~/scripts/preprocess.py"),
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests_workbench_config.py
+++ b/tests/unit_tests_workbench_config.py
@@ -232,9 +232,7 @@ class TestWorkbenchConfig(unittest.TestCase):
 
         args = self.parser.parse_args(["--config", test_file_name])
 
-        with patch("WorkbenchConfig.logging") as mocked_logging:
-            mocked_logging.return_value = None
-
+        with patch("WorkbenchConfig.logging.basicConfig"):
             test_config_obj = WorkbenchConfig(args)
             config = test_config_obj.get_config()
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -3453,6 +3453,7 @@ def check_input(config: dict, args: Namespace) -> None:
                     not file_check_row["file"].startswith("http")
                     and len(file_check_row["file"].strip()) > 0
                 ):
+                    file_check_row["file"] = os.path.expanduser(file_check_row["file"])
                     if os.path.isabs(file_check_row["file"]):
                         file_path = file_check_row["file"]
                     else:
@@ -10703,6 +10704,7 @@ def check_file_exists(config: dict, filename: str) -> bool:
 
     # It's a local file.
     else:
+        filename = os.path.expanduser(filename)
         if os.path.isabs(filename):
             file_path = filename
         else:
@@ -10847,6 +10849,7 @@ def get_preprocessed_file_path(
         return downloaded_file_path
     # It's a local file.
     else:
+        file_path_from_csv = os.path.expanduser(file_path_from_csv)
         if os.path.isabs(file_path_from_csv):
             file_path = file_path_from_csv
         else:


### PR DESCRIPTION
## Link to Github issue or other discussion
#1013 | Replaces #1014 with a cleaner branch.

## What does this PR do?
Adds support for using the tilde (`~`) character to represent the user's home directory in Workbench configuration values and CSV file columns. This makes configuration files more portable across workstations and reduces git conflicts when teams share configs, `~/path/to/file` works everywhere instead of `/home/username/path/to/file`.

## What changes were made?

**WorkbenchConfig.py**
- Expands tilde in the `--config` file path itself at init time
- Expands tilde in `credentials_file_path` and `credentials_key_file_path` during credential loading
- In `get_user_config()`, expands tilde across all relevant path config keys: `input_dir`, `input_csv`, `log_file_path`, `output_csv`, `credentials_file_path`, `credentials_key_file_path`, `export_csv_file_path`, `export_file_directory`, `contact_sheet_output_dir`, `contact_sheet_css_path`, `rollback_dir`, `csv_id_to_node_id_map_dir`, `csv_id_to_node_id_map_path`, `sqlite_db_filename`, `path_to_workbench_script`, `path_to_python`, `check_lock_file_path`, `rollback_csv_file_path`, `rollback_config_file_path`
- Expands tilde in list-based hook script keys (`bootstrap`, `shutdown`, `node_post_create`, `node_post_update`, `media_post_create`, `run_scripts`), correctly handling entries with an interpreter prefix (e.g. `python ~/scripts/foo.py`)
- Expands tilde in preprocessor script paths (both bare scripts and interpreter-prefixed entries)

**workbench_utils.py**
- Expands tilde in file paths read from the CSV `file` column in `check_input()`, `check_file_exists()`, and `get_preprocessed_file_path()`

**Tests**
- Added `test_get_config_expanduser_paths` to `tests/unit_tests_workbench_config.py` covering path config keys, list hook scripts (with and without interpreter prefix), and preprocessor dicts
- Added `tests/assets/WorkbenchConfig_test/config_03_expanduser_paths.yml` as the test fixture

## How to test / verify this PR?
1. Create a config file using tilde paths:
```yaml
task: create
host: http://localhost:8000
username: admin
input_dir: ~/workbench_test/input
log_file_path: ~/workbench_test/logs/workbench.log
credentials_file_path: ~/config/credentials.yml
bootstrap:
  - ~/scripts/bootstrap.sh
  - python ~/scripts/setup.py
```
2. Run `--check` — paths should resolve to full absolute paths with no errors
3. Use a CSV with tilde paths in the `file` column — files should be found correctly
4. Verify that absolute paths and paths without tilde remain unchanged
5. Run the new unit tests: `python tests/unit_tests_workbench_config.py`

## Interested Parties
@mjordan, @sacda-ufv, @south-asian-canadian-digital-archive

---

## Checklist
* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [x] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?