### PR TITLE
Switch to use unprivileged media_type endpoint

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -489,10 +489,10 @@ def check_integration_module_version(config: dict, log_success: bool = True) -> 
     log_message = f'Drupal must be running version {integration_module_min_version} or higher of the Islandora Workbench Integration module. ({config["host"]} is running version {version}).'
 
     #####################################################################################################################
-    # Add logic here that maps a feature to a miniumum Integration module version, and produces a specific log message. #
+    # Add logic here that maps a feature to a minimum Integration module version, and produces a specific log message. #
     #####################################################################################################################
     if config["use_workbench_permissions"] is True:
-        integration_module_min_version = "1.2"
+        integration_module_min_version = "1.2.2"
         log_message = f'In order to use the "use_workbench_permissions" config setting, Drupal must be running version {integration_module_min_version} or higher of the Islandora Workbench Integration module ({config["host"]} is running version {version}).'
     #####################################################################################################################
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -893,7 +893,12 @@ def ping_media_bundle(config: dict, bundle_name: str) -> int:
     int
         The HTTP response code.
     """
-    url = config["host"] + "/entity/media_type/" + bundle_name + "?_format=json"
+    url = (
+        config["host"]
+        + f"/islandora_workbench_integration/media_actions/entity_type/{bundle_name}"
+        if config["use_workbench_permissions"]
+        else config["host"] + "/entity/media_type/" + bundle_name + "?_format=json"
+    )
     response = issue_request(config, "GET", url)
     return response.status_code
 


### PR DESCRIPTION
## Link to Github issue or other discussion

#1100 

## What does this PR do?

If you are not an administrator you can still check for the existence of a media_type.

## What changes were made?

This PR and https://github.com/mjordan/islandora_workbench_integration/pull/47

## How to test / verify this PR?

If you try to ingest when not an admin I was seeing errors in my Drupal logs like 

```
Path: /entity/media_type/file?_format=json. Drupal\Core\Http\Exception\CacheableAccessDeniedHttpException: The 'administer media types' permission is required. in Drupal\Core\Routing\AccessAwareRouter->checkAccess() (line 117 of /var/www/html/islandora/web/core/lib/Drupal/Core/Routing/AccessAwareRouter.php).
```

When using a user with the `use_workbench_permissions` setting.

This PR and the change to islandora_workbench_integration fixed it for me.

## Interested Parties

@mjordan

---

## Checklist

* [X] Before opening this PR, have you opened an issue explaining what you want to to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [ ] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
