### PR TITLE
Fix Python interpreter handling for secondary tasks and hook scripts

### DIFF
--- a/tests/islandora_tests_hooks.py
+++ b/tests/islandora_tests_hooks.py
@@ -33,8 +33,29 @@ class TestExecuteBootstrapScript:
             dir_path, "assets", "execute_bootstrap_script_test", "config.yml"
         )
 
+        config = {"show_bootstrap_script_output": False}
         output, return_code = workbench_utils.execute_bootstrap_script(
-            script_path, config_file_path
+            config, script_path, config_file_path
+        )
+        assert output.strip() == "Hello"
+
+    def test_execute_python_script_multi_token_interpreter(self):
+        """A script registered with a multi-token interpreter prefix (e.g. "uv run python
+        script.py") must not raise ValueError: too many values to unpack."""
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+
+        script_path = os.path.join(
+            dir_path, "assets", "execute_bootstrap_script_test", "script.py"
+        )
+        config_file_path = os.path.join(
+            dir_path, "assets", "execute_bootstrap_script_test", "config.yml"
+        )
+
+        config = {"show_bootstrap_script_output": False}
+        # 3 tokens: interpreter + flag + script.
+        command = f"{sys.executable} -u {script_path}"
+        output, return_code = workbench_utils.execute_bootstrap_script(
+            config, command, config_file_path
         )
         assert output.strip() == "Hello"
 
@@ -46,8 +67,23 @@ class TestExecutePreprocessorScript:
         script_path = os.path.join(
             dir_path, "assets", "preprocess_field_data", "script.py"
         )
+        config = {"subdelimiter": "|", "config_file_path": ""}
         output, return_code = workbench_utils.preprocess_field_data(
-            "|", "hello", script_path
+            config, "hello", script_path
+        )
+        assert output.strip() == "HELLO"
+
+    def test_preprocessor_script_multi_token_interpreter(self):
+        """A preprocessor registered with a multi-token interpreter prefix must run the
+        script intact rather than dropping the leading tokens."""
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        script_path = os.path.join(
+            dir_path, "assets", "preprocess_field_data", "script.py"
+        )
+        config = {"subdelimiter": "|", "config_file_path": ""}
+        command = f"{sys.executable} -u {script_path}"
+        output, return_code = workbench_utils.preprocess_field_data(
+            config, "hello", command
         )
         assert output.strip() == "HELLO"
 
@@ -56,8 +92,9 @@ class TestExecutePreprocessorScript:
         script_path = os.path.join(
             dir_path, "assets", "preprocess_field_data", "script.py"
         )
+        config = {"subdelimiter": "|", "config_file_path": ""}
         output, return_code = workbench_utils.preprocess_field_data(
-            "|", "hello|there", script_path
+            config, "hello|there", script_path
         )
         assert output.strip() == "HELLO|THERE"
 

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -4280,17 +4280,13 @@ def check_input(config: dict, args: Namespace) -> None:
                 + secondary_config_file
                 + '"'
             )
-            if os.name == "nt":
-                # Assumes python.exe is in the user's PATH.
-                cmd = [
-                    "python",
-                    "./workbench",
-                    "--config",
-                    secondary_config_file,
-                    "--check",
-                ]
-            else:
-                cmd = ["./workbench", "--config", secondary_config_file, "--check"]
+            cmd = [
+                config["path_to_python"],
+                config["path_to_workbench_script"],
+                "--config",
+                secondary_config_file,
+                "--check",
+            ]
             output = subprocess.run(cmd)
 
         sys.exit(0)

--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -4001,7 +4001,7 @@ def check_input(config: dict, args: Namespace) -> None:
         bootsrap_scripts_present = True
         for bootstrap_script in config["bootstrap"]:
             if " " in bootstrap_script:
-                interpeter, bootstrap_script = bootstrap_script.split(" ")
+                bootstrap_script = bootstrap_script.split(" ")[-1]
             if not os.path.exists(bootstrap_script):
                 message = "Bootstrap script " + bootstrap_script + " not found."
                 logging.error(message)
@@ -4182,7 +4182,7 @@ def check_input(config: dict, args: Namespace) -> None:
 
         for script_to_run in config["run_scripts"]:
             if " " in script_to_run:
-                interpeter, script_to_run = script_to_run.split(" ", 1)
+                script_to_run = script_to_run.split(" ")[-1]
             if not os.path.exists(script_to_run.strip()):
                 message = "Script " + script_to_run + " not found."
                 logging.error(message)
@@ -5202,18 +5202,11 @@ def preprocess_field_data(config, field_value: str, path_to_script: str) -> tupl
     """
     subdelimiter = config["subdelimiter"]
     config_file_path = config["config_file_path"]
-    if " " in path_to_script:
-        script = path_to_script.split(" ")[-1]
-        interpeter = path_to_script.split(" ")[-2]
-        cmd = subprocess.Popen(
-            [interpeter, script, subdelimiter, field_value, config_file_path],
-            stdout=subprocess.PIPE,
-        )
-    else:
-        cmd = subprocess.Popen(
-            [path_to_script, subdelimiter, field_value, config_file_path],
-            stdout=subprocess.PIPE,
-        )
+    *interpreter, script = path_to_script.split(" ")
+    cmd = subprocess.Popen(
+        [*interpreter, script, subdelimiter, field_value, config_file_path],
+        stdout=subprocess.PIPE,
+    )
     result, stderrdata = cmd.communicate()
     result = result.decode().strip()
 
@@ -5229,15 +5222,10 @@ def execute_bootstrap_script(
     :param path_to_config_file: str - The absolute path to the Workbench config file.
     :return: tuple - The output of the script (stdout) and the script's return code.
     """
-    if " " in path_to_script:
-        interpeter, script = path_to_script.split(" ")
-        cmd = subprocess.Popen(
-            [interpeter, script, path_to_config_file], stdout=subprocess.PIPE
-        )
-    else:
-        cmd = subprocess.Popen(
-            [path_to_script, path_to_config_file], stdout=subprocess.PIPE
-        )
+    *interpreter, script = path_to_script.split(" ")
+    cmd = subprocess.Popen(
+        [*interpreter, script, path_to_config_file], stdout=subprocess.PIPE
+    )
     result, stderrdata = cmd.communicate()
     result = result.decode().strip()
 
@@ -5256,16 +5244,10 @@ def execute_shutdown_script(
     :param path_to_config_file: str - The absolute path to the Workbench config file
     :return: tuple - The output of the script (stdout) and the script's return code.
     """
-    if " " in path_to_script:
-        interpeter, script = path_to_script.split(" ")
-        cmd = subprocess.Popen(
-            [interpeter, script, path_to_config_file], stdout=subprocess.PIPE
-        )
-
-    else:
-        cmd = subprocess.Popen(
-            [path_to_script, path_to_config_file], stdout=subprocess.PIPE
-        )
+    *interpreter, script = path_to_script.split(" ")
+    cmd = subprocess.Popen(
+        [*interpreter, script, path_to_config_file], stdout=subprocess.PIPE
+    )
     result, stderrdata = cmd.communicate()
     result = result.decode().strip()
 
@@ -5282,24 +5264,18 @@ def execute_entity_post_task_script(
     filename: str = "",
 ):
     """Executes a entity-level post-task script and returns its output and exit status code."""
-    if " " in path_to_script:
-        interpeter, script = path_to_script.split(" ")
-        cmd = subprocess.Popen(
-            [
-                interpeter,
-                script,
-                path_to_config_file,
-                str(http_response_code),
-                entity_json,
-                filename,
-            ],
-            stdout=subprocess.PIPE,
-        )
-    else:
-        cmd = subprocess.Popen(
-            [path_to_script, path_to_config_file, str(http_response_code), entity_json],
-            stdout=subprocess.PIPE,
-        )
+    *interpreter, script = path_to_script.split(" ")
+    cmd = subprocess.Popen(
+        [
+            *interpreter,
+            script,
+            path_to_config_file,
+            str(http_response_code),
+            entity_json,
+            filename,
+        ],
+        stdout=subprocess.PIPE,
+    )
 
     result, stderrdata = cmd.communicate()
     result = result.decode().strip()
@@ -5338,22 +5314,16 @@ def execute_script_to_run(
             entity_id = get_tid_from_term_url_alias(config, entity_id)
 
     try:
-        if " " in path_to_script:
-            interpeter, script = path_to_script.split(" ", 1)
-            cmd = subprocess.Popen(
-                [
-                    interpeter.strip(),
-                    script.strip(),
-                    config["config_file_path"],
-                    str(entity_id),
-                ],
-                stdout=subprocess.PIPE,
-            )
-        else:
-            cmd = subprocess.Popen(
-                [path_to_script, config["config_file_path"], str(entity_id)],
-                stdout=subprocess.PIPE,
-            )
+        *interpreter, script = path_to_script.split(" ")
+        cmd = subprocess.Popen(
+            [
+                *interpreter,
+                script,
+                config["config_file_path"],
+                str(entity_id),
+            ],
+            stdout=subprocess.PIPE,
+        )
 
         result, stderrdata = cmd.communicate()
         result = result.decode(errors="replace").strip()


### PR DESCRIPTION
## Link to Github issue or other discussion

Comment in [#1078](https://github.com/mjordan/islandora_workbench/issues/1078#issuecomment-4680737933)

## What does this PR do?

Fixes two related bugs in how Workbench invokes the Python interpreter for the
subprocesses it shells out to:

1. Secondary tasks in `--check` mode now use the primary task's configured interpreter.
2. Hook scripts (bootstrap, shutdown, preprocessor, post-action, run_scripts) now correctly
   handle interpreter prefixes with more than one token, e.g. `uv run python script.py`.

## What changes were made?

1. Secondary task `--check` uses the primary task's interpreter

When a primary task has `secondary_tasks` configured, Workbench shells out to a subprocess to run each secondary task. The **run** path already uses the configured interpreter (`config["path_to_python"]`, which defaults to `sys.executable`) and `config["path_to_workbench_script"]`, so the secondary subprocess inherits the same virtualenv and dependencies as the primary task.

The **`--check`** path did not. It hardcoded the command as `python ./workbench` on Windows (`os.name == "nt"`) and relied on the `./workbench` shebang on other platforms. This assumes a `python` on `PATH` that happens to have Workbench's dependencies installed and that `./workbench` is resolvable from the current working directory. When Workbench is run from a virtualenv (or via a launcher whose interpreter isn't first on `PATH`), the secondary `--check` task fails, e.g.:

```
Traceback (most recent call last):
  File ".../workbench", line 17, in
    import requests_cache
ModuleNotFoundError: No module named 'requests_cache'
```
`--check` now builds the command from config, mirroring the run path:

```python
cmd = [
    config["path_to_python"],
    config["path_to_workbench_script"],
    "--config",
    secondary_config_file,
    "--check",
]
```

The os.name == "nt" special case was removed entirely — path_to_python already resolves to the correct executable on every platform.

2. Multi-token interpreter support in hook scripts

Hook scripts can be registered with an interpreter prefix, e.g. python ./script.py. The command was parsed by splitting on spaces into exactly two variables:
```python
interpeter, script = path_to_script.split(" ")
```
This raised ValueError: too many values to unpack (expected 2) the moment the command had more than two tokens, e.g. a shutdown script configured as uv run python ./scripts/post_action_commit.py:
```
ValueError: too many values to unpack (expected 2)
```
The parsing is now done with starred unpacking, which handles 0, 1, or many interpreter tokens:
```
*interpreter, script = path_to_script.split(" ")
cmd = subprocess.Popen([*interpreter, script, <args...>], stdout=subprocess.PIPE)
```
Applied to every execution function (execute_bootstrap_script, execute_shutdown_script, execute_entity_post_task_script, preprocess_field_data, execute_script_to_run) and the matching validation paths in check_input() (bootstrap and run_scripts, which previously either crashed or reported a valid script as "not found").

## How to test / verify this PR?

- Secondary --check: configure a primary task with secondary_tasks and run `./workbench --config primary.yml --check` from a virtualenv whose interpreter is not first on PATH; the secondary check now runs without ModuleNotFoundError.
- Multi-token hooks: register a hook (e.g. shutdown) as uv run python ./script.py and run Workbench; it executes without the too many values to unpack traceback.
- Tests: tests/islandora_tests_hooks.py adds regression cases that invoke bootstrap and preprocessor hooks via a multi-token interpreter (sys.executable -u script.py). The existing hook tests were also updated to the current (config, ...) signatures.

## Interested Parties

@mjordan @south-asian-canadian-digital-archive

---

## Checklist

* [ ] Before opening this PR, have you opened an issue explaining what you want to do?
* [ ] Have you included some configuration and/or CSV files useful for testing this PR?
* [x] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
