### PR TITLE
Fix ValueError when output_csv_include_input_csv is true and CSV has media track fields

### DIFF
--- a/workbench_utils.py
+++ b/workbench_utils.py
@@ -9513,6 +9513,9 @@ def write_to_output_csv(
         for reserved_field in reserved_fields:
             if reserved_field in input_csv_row:
                 input_csv_row_fieldnames.remove(reserved_field)
+        for field_name in input_csv_row_fieldnames:
+            if field_name not in node_field_names:
+                node_field_names.append(field_name)
 
     writer = csv.DictWriter(csvfile, fieldnames=node_field_names, lineterminator="\n")
 


### PR DESCRIPTION
## Summary

- When `output_csv_include_input_csv: true` is set and the input CSV contains media track columns (`media:video:field_track`, `media:audio:field_track`, `media_use_tid`), workbench crashes with `ValueError: dict contains fields not in fieldnames`.
- Root cause: `input_csv_row_fieldnames` was computed (stripping reserved fields from the input CSV keys) but never used to extend `node_field_names` before the `csv.DictWriter` was constructed. So when `row.update(input_csv_row)` added those keys to the row dict, `writer.writerow()` raised because the writer did not know about them.
- Fix: after building `input_csv_row_fieldnames`, append any field names not already in `node_field_names` before creating the `DictWriter`.

## Test plan

- [ ] Create a CSV with `media:video:field_track` and/or `media:audio:field_track` columns (per the [media track files docs](https://mjordan.github.io/islandora_workbench_docs/media_track_files/))
- [ ] Set `output_csv_include_input_csv: true` in the config
- [ ] Run a `create` task and confirm it completes without `ValueError`
- [ ] Confirm the output CSV includes the media track columns

Generated with [Claude Code](https://claude.com/claude-code)
