### PR TITLE
Improve Docker build caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,11 @@ ARG GROUP_ID
 RUN groupadd -g $GROUP_ID dockeruser || true
 
 # Create a user with the specified UID and GID
-RUN useradd -m -u $USER_ID -g $GROUP_ID -s /bin/bash dockeruser
+RUN useradd -l -m -u $USER_ID -g $GROUP_ID -s /bin/bash dockeruser
 
 # Set the working directory
 WORKDIR /workbench
-
-# Copy the current directory contents into the container at /workbench
-COPY . /workbench/
-
-# Set ownership and permissions for the non-root user
-RUN chown -R $USER_ID:$GROUP_ID /workbench
+RUN chown $USER_ID:$GROUP_ID /workbench
 
 # Set the PATH environment variable to include .local/bin
 ENV PATH=/home/dockeruser/.local/bin:$PATH
@@ -38,11 +33,21 @@ ENV PATH=/home/dockeruser/.local/bin:$PATH
 # Set an environment variable to indicate Workbench is running in a Docker container.
 ENV ISLANDORA_WORKBENCH_IS_RUNNING_IN_DOCKER=True
 
-# Switch to the non-root user
-USER dockeruser
+# Install dependencies from the project metadata before copying the application source.
+# This layer remains cached when only Workbench's source files change.
+COPY --chown=$USER_ID:$GROUP_ID pyproject.toml README.md requirements-docker.txt /workbench/
 
-# Install dependencies and setup the environment
-RUN python -m pip install --user --upgrade pip setuptools build && \
-    python -m pip install --user --no-cache-dir "urllib3>=1.21.1" libmagic && \
-    python -m build && \
-    python -m pip install --user dist/*.whl
+# USER_ID is supplied as a numeric UID by the documented build command.
+# hadolint ignore=DL3066
+USER $USER_ID
+
+# Install build and runtime dependencies.
+RUN python -m pip install --user --no-cache-dir --requirement requirements-docker.txt && \
+    python -m pip install --user --no-cache-dir --only-deps .
+
+# Copy and install the application separately so source changes only invalidate
+# the comparatively inexpensive application build layer.
+COPY --chown=$USER_ID:$GROUP_ID . /workbench/
+
+RUN python -m build --wheel --no-isolation && \
+    python -m pip install --user --no-cache-dir --no-deps dist/*.whl

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,0 +1,6 @@
+# Docker-specific build and runtime dependencies.
+build==1.5.0
+libmagic==1.0
+pip==26.2
+setuptools==83.0.0
+urllib3==2.7.0


### PR DESCRIPTION
## Link to Github issue or other discussion

No separate issue is linked. This PR addresses slow Docker rebuilds after changes to Workbench source files.

## What does this PR do?

Improves Docker layer caching so editing workbench or other application source files does not reinstall all Python dependencies.

The dependency layer now changes only when project metadata or Docker-specific requirements change. Source-only rebuilds reuse that layer and perform only the lightweight application wheel build and install.
  
## What changes were made?

- Copy dependency metadata before application source.
- Install project dependencies in a reusable Docker layer.
- Add requirements-docker.txt with pinned Docker-specific dependencies.
- Copy application files afterward using COPY --chown.
- Build only the wheel, without an isolated build environment.
- Install the application wheel with --no-deps.
- Disable pip’s internal cache while retaining Docker layer caching.
- Resolve Hadolint warnings for user creation, pip installation, and version pinning.
- Preserve configurable numeric host UID/GID handling.

## How to test / verify this PR?

Ideally this repo's Dockerfile gets used in CI tests here in GitHub. If not, I'll add some. but to test locally, you can build the image:

```
  docker build \
    --progress=plain \
    --build-arg USER_ID=$(id -u) \
    --build-arg GROUP_ID=$(id -g) \
    -t workbench-docker .
```

Make a temporary content change to workbench source files, then run the same build again. Confirm that the dependency installation step is reported as CACHED.

Run the lint and runtime checks:

```
hadolint Dockerfile
docker run --rm workbench-docker \
  bash -lc 'python -m pip check && ./workbench --help >/dev/null'
```
No YAML configuration or CSV test data is required because this changes only the Docker build process.

## Interested Parties

@mjordan

---

## Checklist

- [ ] Before opening this PR, have you opened an issue explaining what you want to to do?
- [x] Testing configuration and CSV files — Not applicable to this build-only change.
- [x] Tests — Docker lint, build, cache-reuse, dependency, and runtime checks are documented above.
- [x] Python minimum version — Unchanged.
- [x] Python libraries — No new application dependency; Docker-specific dependencies are pinned in requirements-docker.txt.
- [x] Configuration defaults — No configuration option was added.
