### PR TITLE
Log unhandled exceptions to workbench.log before the run terminates (#1119)

### DIFF
--- a/workbench
+++ b/workbench
@@ -3687,3 +3687,10 @@ except KeyboardInterrupt:
         sys.exit(0)
     except SystemExit:
         os._exit(0)
+except Exception:
+    # Record the failure in the log before the exception propagates. Without this,
+    # a run that ends in an unhandled exception writes nothing to the log, so anything
+    # reading the log rather than the console cannot tell a crash from a killed run.
+    # Re-raising leaves console output and the exit code unchanged.
+    logging.exception("Workbench exited with an unhandled exception.")
+    raise


### PR DESCRIPTION
## Link to Github issue or other discussion

#1119

## What does this PR do?

Logs unhandled exceptions to `workbench.log` before they terminate the run.

The top-level task dispatch currently catches only `KeyboardInterrupt`, so any other exception propagates out of `create()` (or whichever task is running) and ends the process without any logging call running. The traceback goes to the console and the log simply stops mid-run, with nothing to distinguish a crash from a killed run. That's fine interactively, but invisible to anything reading the log rather than stdout — a scheduler, a wrapper script, or a UI.

## What changes were made?

One `except Exception` clause added to the task-dispatch `try` at the end of `workbench`:

```python
except Exception:
    logging.exception("Workbench exited with an unhandled exception.")
    raise
```

`logging.exception()` records the traceback at ERROR level, and `logging.basicConfig(filename=config["log_file_path"], ...)` has already run by the time the dispatch block executes, so it lands in the configured log file.

The bare `raise` re-raises rather than exiting. Since `rich.traceback.install()` runs in `workbench_utils.py`, the console traceback renders exactly as it does today and the exit code is unchanged — interactive behaviour is identical.

## How to test / verify this PR?

Any unhandled exception during a task reproduces it. One easy route is the `ValueError` in #1118: a `create` task with `output_csv_include_input_csv: true` and a CSV containing a column that isn't in the output CSV's fieldnames.

- **Before:** traceback on the console, nothing in `workbench.log` — the log's last line is whatever the run was doing.
- **After:** same console traceback and exit code, plus an ERROR entry with the traceback in `workbench.log`:

```
28-Aug-26 18:10:47 - INFO - "Create" task started.
28-Aug-26 18:10:47 - ERROR - Workbench exited with an unhandled exception.
Traceback (most recent call last):
  ...
ValueError: dict contains fields not in fieldnames: 'media_use_tid'
```

I ran `black --check` (clean, no reformatting needed) and the three CI suites: `tests/unit_tests.py` (92), `tests/field_tests.py` (105) and `tests/csv_id_to_node_id_map_tests.py` (5), all passing.

## Interested Parties

@mjordan

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do? — #1119
* [ ] Have you included some configuration and/or CSV files useful for testing this PR? — not data-dependent; any unhandled exception reproduces it
* [ ] Have you written unit or integration tests if applicable? — see note below
* [x] Does the code added in this PR require a version of Python that is higher than the current minimum version? — no
* [x] If the changes in this PR require an additional Python library, have you included it in `setup.py`? — no new libraries
* [x] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file? — no new options

A note on tests: the change is at module scope in `workbench`, which the existing suites don't import, so I haven't added one. Happy to add a test if you can suggest where it would fit.

One suggestion beyond the scope of #1119: the `--check` block just above has the same shape, catching only `KeyboardInterrupt`, so a crash during `--check` is just as silent as a crash during the run. I'd suggest the same handler there. I kept it out of this PR because #1119 only describes the dispatch block and I didn't want to widen the diff without asking — say the word and I'll add it here, or open a separate issue for it.